### PR TITLE
Interactive 3DCityDB setup scripts

### DIFF
--- a/PostgreSQL/SQLScripts/CREATE_DB.bat
+++ b/PostgreSQL/SQLScripts/CREATE_DB.bat
@@ -1,17 +1,50 @@
-REM Shell script to create an instance of the 3D City Database
-REM on PostgreSQL/PostGIS
+@echo off
+:: Shell script to create an instance of the 3D City Database
+:: on PostgreSQL/PostGIS
 
-REM Provide your database details here
+:: Provide your database details here
 set PGPORT=5432
 set PGHOST=your_host_address
 set PGUSER=your_username
 set CITYDB=your_database
 set PGBIN=path_to_psql.exe
 
-REM cd to path of the shell script
+:: cd to path of the shell script
 cd /d %~dp0
 
-REM Run CREATE_DB.sql to create the 3D City Database instance
-"%PGBIN%\psql" -d "%CITYDB%" -f "CREATE_DB.sql"
+:: Prompt for srsno
+:srid_retry
+set var=
+echo.
+echo Please enter a valid SRID (e.g., 3068 for DHDN/Soldner Berlin).
+echo Press ENTER to use default.
+set /p var="(default=3068): "
 
-pause
+IF /i NOT "%var%"=="" (
+  set srsno=%var%
+) else (
+  set srsno=3068
+)
+
+:: SRID is numeric?
+SET "num="&for /f "delims=0123456789" %%i in ("%var%") do set num=%%i
+IF defined num (
+  echo.
+  echo SRID must be numeric. Please retry.
+  goto:srid_retry
+)
+
+:: Prompt for gmlsrsname
+echo.
+echo Please enter the corresponding SRSName to be used in GML exports (e.g., urn:ogc:def:crs,crs:EPSG::3068,crs:EPSG::5783).
+echo Press ENTER to use default.
+set /p var="(default=urn:ogc:def:crs,crs:EPSG::3068,crs:EPSG::5783): "
+
+IF /i NOT "%var%"=="" (
+  set gmlsrsname=%var%
+) else (
+  set gmlsrsname=urn:ogc:def:crs,crs:EPSG::3068,crs:EPSG::5783
+)
+
+:: Run CREATE_DB.sql to create the 3D City Database instance
+"%PGBIN%\psql" -d "%CITYDB%" -f "CREATE_DB.sql" -v srsno="%srsno%" -v gmlsrsname="%gmlsrsname%"

--- a/PostgreSQL/SQLScripts/CREATE_DB.sh
+++ b/PostgreSQL/SQLScripts/CREATE_DB.sh
@@ -9,8 +9,31 @@ export PGUSER=your_username
 export CITYDB=your_database
 export PGBIN=path_to_psql
 
+# Prompt for SRSNO
+regex='^[0-9]+$'
+while [ 1 ]; do
+  echo
+  echo 'Please enter a valid SRID (e.g., 3068 for DHDN/Soldner Berlin).'
+  echo 'Press ENTER to use default.'
+  read -p "(default=3068): " SRSNO
+  SRSNO=${SRSNO:-3068}
+   
+  if [[ ! $SRSNO =~ $regex ]]; then
+    echo 'SRSNO must be numeric. Please retry.'
+  else 
+    break;
+  fi
+done
+
+# Prompt for GMLSRSNAME
+echo
+echo 'Please enter the corresponding SRSName to be used in GML exports (e.g., urn:ogc:def:crs,crs:EPSG::3068,crs:EPSG::5783).'
+echo 'Press ENTER to use default.'
+read -p '(default=urn:ogc:def:crs,crs:EPSG::3068,crs:EPSG::5783): ' GMLSRSNAME
+GMLSRSNAME=${GMLSRSNAME:-urn:ogc:def:crs,crs:EPSG::3068,crs:EPSG::5783}
+
 # cd to path of the shell script
 cd "$( cd "$( dirname "$0" )" && pwd )" > /dev/null
 
 # Run CREATE_DB.sql to create the 3D City Database instance
-"$PGBIN/psql" -d "$CITYDB" -f "CREATE_DB.sql"
+"$PGBIN/psql" -d "$CITYDB" -f "CREATE_DB.sql" -v srsno="$SRSNO" -v gmlsrsname="$GMLSRSNAME"

--- a/PostgreSQL/SQLScripts/CREATE_DB.sql
+++ b/PostgreSQL/SQLScripts/CREATE_DB.sql
@@ -25,16 +25,18 @@
 -- limitations under the License.
 --
 
--- This script is called from CREATE_DB.bat
+-- This script is called from CREATE_DB.bat/CREATE_DB.sh
 \pset footer off
 SET client_min_messages TO WARNING;
 \set ON_ERROR_STOP ON
 
-\echo
-\prompt 'Please enter a valid SRID (e.g., 3068 for DHDN/Soldner Berlin): ' SRS_NO
-\prompt 'Please enter the corresponding SRSName to be used in GML exports (e.g., urn:ogc:def:crs,crs:EPSG::3068,crs:EPSG::5783): ' GMLSRSNAME
+-- Parse arguments srsno, gmlsrsname
+\echo :srsno
+\echo :gmlsrsname
 
-\set SRSNO :SRS_NO
+\set SRSNO :srsno
+\set SRS_NO :srsno
+\set GMLSRSNAME :gmlsrsname
 
 --// check if the PostGIS extension is available
 SELECT postgis_version();


### PR DESCRIPTION
As discussed on the mailing list a while ago, I offered to create scripts that will guide the user trough the setup process of a 3DCityDB, similar to the *quickstart scripts* I created for the [3DCityDB Docker images](https://github.com/tum-gis/3dcitydb-docker-postgis). Take a look at 

The scripts shall...
* ...*print information* on where to find required software/documentation/help/examples
* ...*interactively prompt* the user for all required configuration parameters/database connection credentials
* ...maybe do some *checks on the user input*
* and *perform the 3DCityDB setup*. 

This is inteded to help unexperienced users to get going with the 3DCityDB and make the setup process more convenient.
