### PR TITLE
Setup script arguments

### DIFF
--- a/Oracle/SQLScripts/CREATE_DB.bat
+++ b/Oracle/SQLScripts/CREATE_DB.bat
@@ -98,27 +98,25 @@ IF "%res%"=="f" (
 
 :: Run CREATE_DB.sql to create the 3D City Database instance ------------------
 sqlplus "%USERNAME%@\"%HOST%:%PORT%/%SID%\"" @CREATE_DB.sql "%SRSNO%" "%GMLSRSNAME%" "%VERSIONING%" "%DBVERSION%"
-
 GOTO:EOF
 
-:args
 :: Correct number of args present? --------------------------------------------
+:args
 set argC=0
 for %%x in (%*) do Set /A argC+=1
 
-echo %argC%
-
 if NOT %argC% EQU 9 (
   echo ERROR: Invalid number of arguments. 1>&2
+  call :usage
   GOTO:EOF
 )
 
 :: Parse args -----------------------------------------------------------------
 :: %1 = HOST
-:: %2 = POST
+:: %2 = PORT
 :: %3 = SID
 :: %4 = USERNAME
-:: $5 = PASSWORD
+:: %5 = PASSWORD
 :: %6 = DBVERSION
 :: %7 = VERSIONING
 :: %8 = SRSNO
@@ -136,3 +134,22 @@ set GMLSRSNAME=%9
 
 :: Run CREATE_DB.sql to create the 3D City Database instance ------------------
 sqlplus "%USERNAME%/\"%PASSWORD%\"@\"%HOST%:%PORT%/%SID%\"" @CREATE_DB.sql "%SRSNO%" "%GMLSRSNAME%" "%VERSIONING%" "%DBVERSION%"
+GOTO:EOF
+
+:: Print usage information ----------------------------------------------------
+:usage
+echo. 1<&2
+echo Usage: %~n0%~x0 HOST PORT SID USERNAME PASSWORD DBVERSION VERSIONING SRSNO GMLSRSNAME 1>&2
+echo No args can be ommitted and the order is mandatory. 1>&2
+echo. 1>&2
+echo HOST          Database host 1>&2
+echo PORT          Database port 1>&2
+echo SID           Database sid 1>&2
+echo USERNAME      Database username 1>&2
+echo PASSWORD      Database password 1>&2
+echo DBVERSION     Database license type, Oracle (S)patial or Oracle (L)ocator (S/L) 1>&2
+echo VERSIONING    Enable database versioning (yes/no) 1>&2
+echo SRSNO         Spatial reference system number (SRID) 1>&2
+echo GMLSRSNAME    SRSName to be used in GML exports 1>&2
+echo. 1>&2
+GOTO:EOF

--- a/Oracle/SQLScripts/CREATE_DB.bat
+++ b/Oracle/SQLScripts/CREATE_DB.bat
@@ -20,6 +20,7 @@ if NOT [%1]==[] (
   GOTO:args
 )
 
+:: INTERACTIVE MODE -----------------------------------------------------------
 :: Prompt for SRSNO -----------------------------------------------------------
 :srid
 set var=
@@ -40,7 +41,6 @@ IF defined num (
   echo SRID must be numeric. Please retry.
   goto:srid
 )
-
 
 :: Prompt for GMLSRSNAME ------------------------------------------------------
 set var=
@@ -100,7 +100,7 @@ IF "%res%"=="f" (
 sqlplus "%USERNAME%@\"%HOST%:%PORT%/%SID%\"" @CREATE_DB.sql "%SRSNO%" "%GMLSRSNAME%" "%VERSIONING%" "%DBVERSION%"
 GOTO:EOF
 
-:: Correct number of args present? --------------------------------------------
+:: Correct number of args supplied? -------------------------------------------
 :args
 set argC=0
 for %%x in (%*) do Set /A argC+=1

--- a/Oracle/SQLScripts/CREATE_DB.bat
+++ b/Oracle/SQLScripts/CREATE_DB.bat
@@ -15,6 +15,11 @@ set PATH=%SQLPLUSBIN%;%PATH%
 :: cd to path of the shell script
 cd /d %~dp0
 
+:: Interactive mode or usage with arguments? ----------------------------------
+if NOT [%1]==[] (
+  GOTO:args
+)
+
 :: Prompt for SRSNO -----------------------------------------------------------
 :srid
 set var=
@@ -35,6 +40,7 @@ IF defined num (
   echo SRID must be numeric. Please retry.
   goto:srid
 )
+
 
 :: Prompt for GMLSRSNAME ------------------------------------------------------
 set var=
@@ -93,4 +99,40 @@ IF "%res%"=="f" (
 :: Run CREATE_DB.sql to create the 3D City Database instance ------------------
 sqlplus "%USERNAME%@\"%HOST%:%PORT%/%SID%\"" @CREATE_DB.sql "%SRSNO%" "%GMLSRSNAME%" "%VERSIONING%" "%DBVERSION%"
 
-pause
+GOTO:EOF
+
+:args
+:: Correct number of args present? --------------------------------------------
+set argC=0
+for %%x in (%*) do Set /A argC+=1
+
+echo %argC%
+
+if NOT %argC% EQU 9 (
+  echo ERROR: Invalid number of arguments. 1>&2
+  GOTO:EOF
+)
+
+:: Parse args -----------------------------------------------------------------
+:: %1 = HOST
+:: %2 = POST
+:: %3 = SID
+:: %4 = USERNAME
+:: $5 = PASSWORD
+:: %6 = DBVERSION
+:: %7 = VERSIONING
+:: %8 = SRSNO
+:: %9 = GMLSRSNAME
+
+set HOST=%1
+set PORT=%2
+set SID=%3
+set USERNAME=%4
+set PASSWORD=%5
+set DBVERSION=%6
+set VERSIONING=%7
+set SRSNO=%8
+set GMLSRSNAME=%9
+
+:: Run CREATE_DB.sql to create the 3D City Database instance ------------------
+sqlplus "%USERNAME%/\"%PASSWORD%\"@\"%HOST%:%PORT%/%SID%\"" @CREATE_DB.sql "%SRSNO%" "%GMLSRSNAME%" "%VERSIONING%" "%DBVERSION%"

--- a/Oracle/SQLScripts/CREATE_DB.sh
+++ b/Oracle/SQLScripts/CREATE_DB.sh
@@ -12,68 +12,110 @@ export USERNAME=your_username
 
 # add sqlplus to PATH
 PATH=$SQLPLUSBIN:$PATH
-
 # cd to path of the shell script
 cd "$( cd "$( dirname "$0" )" && pwd )" > /dev/null
 
-# Prompt for DBVERSION --------------------------------------------------------
-while [ 1 ]; do
+# Interactive mode or usage with arguments? -----------------------------------
+if [ $# -eq 0 ]; then
+  # INTERACTIVE MODE ----------------------------------------------------------
+  # Prompt for DBVERSION ------------------------------------------------------
+  while [ 1 ]; do
+    echo
+    echo 'Which database license are you using? (Oracle Spatial(S)/Oracle Locator(L)): Press ENTER to use default.'
+    read -p "(default DBVERSION=Oracle Spatial(S)): " DBVERSION
+    DBVERSION=${DBVERSION:-S}
+   
+   # to upper case
+    DBVERSION=$(echo "$DBVERSION" | awk '{print toupper($0)}')
+    
+    if [ "$DBVERSION" = "S" ] || [ "$DBVERSION" = "L" ] ; then
+      break;
+    else 
+      echo "Illegal input! Enter S or L."  
+    fi
+  done
+
+  # Prompt for VERSIONING -----------------------------------------------------
+  while [ 1 ]; do
+    echo
+    echo 'Shall versioning be enabled? (yes/no): Press ENTER to use default.'
+    read -p "(default VERSIONING=no): " VERSIONING
+    VERSIONING=${VERSIONING:-no}
+    
+    # to lower case
+    VERSIONING=$(echo "$VERSIONING" | awk '{print tolower($0)}')
+    
+    if [  "$VERSIONING" = "yes" ] || [ "$VERSIONING" = "no" ] ; then
+      break;
+    else 
+      echo "Illegal input! Enter yes or no."  
+    fi
+  done
+
+  # Prompt for SRSNO ----------------------------------------------------------
+  re='^[0-9]+$'
+  while [ 1 ]; do
+    echo
+    echo 'Please enter a valid SRID (e.g. Berlin: 81989002): Press ENTER to use default.'
+    read -p "(default SRID=81989002): " SRSNO
+    SRSNO=${SRSNO:-81989002}
+    
+    if [[ ! $SRSNO =~ $re ]]; then
+      echo 'SRID must be numeric. Please retry.'
+    else 
+      break;
+    fi
+  done
+
+  # Prompt for GMLSRSNAME -----------------------------------------------------
   echo
-  echo 'Which database license are you using? (Oracle Spatial(S)/Oracle Locator(L)): Press ENTER to use default.'
-  read -p "(default DBVERSION=Oracle Spatial(S)): " DBVERSION
-  DBVERSION=${DBVERSION:-S}
- 
- # to upper case
-  DBVERSION=$(echo "$DBVERSION" | awk '{print toupper($0)}')
+  echo 'Please enter the corresponding SRSName to be used in GML exports. Press ENTER to use default.'
+  read -p '(default GMLSRSNAME=urn:ogc:def:crs,crs:EPSG:6.12:3068,crs:EPSG:6.12:5783): ' GMLSRSNAME
+  GMLSRSNAME=${GMLSRSNAME:-urn:ogc:def:crs,crs:EPSG:6.12:3068,crs:EPSG:6.12:5783}
+
+  # Run CREATE_DB.sql to create the 3D City Database instance -----------------
+  sqlplus "${USERNAME}@\"${HOST}:${PORT}/${SID}\"" @CREATE_DB.sql "${SRSNO}" "${GMLSRSNAME}" "${VERSIONING}" "${DBVERSION}"
   
-  if [ "$DBVERSION" = "S" ] || [ "$DBVERSION" = "L" ] ; then
-    break;
-  else 
-    echo "Illegal input! Enter S or L."  
-  fi
-done
-
-# Prompt for VERSIONING -------------------------------------------------------
-while [ 1 ]; do
-  echo
-  echo 'Shall versioning be enabled? (yes/no): Press ENTER to use default.'
-  read -p "(default VERSIONING=no): " VERSIONING
-  VERSIONING=${VERSIONING:-no}
+elif [ $# -ne 9 ]; then
+  # Correct number of args supplied? ------------------------------------------
+  >&2 echo 'ERROR: Invalid number of arguments.'
+  >&2 echo
+  <&2 echo "Usage: $(basename "$0") HOST PORT SID USERNAME PASSWORD DBVERSION VERSIONING SRSNO GMLSRSNAME"
+  <&2 echo 'No args can be ommitted and the order is mandatory.'
+  <&2 echo
+  <&2 echo 'HOST          Database host'
+  <&2 echo 'PORT          Database port'
+  <&2 echo 'SID           Database sid'
+  <&2 echo 'USERNAME      Database username'
+  <&2 echo 'PASSWORD      Database password'
+  <&2 echo 'DBVERSION     Database license type, Oracle (S)patial or Oracle (L)ocator (S/L)'
+  <&2 echo 'VERSIONING    Enable database versioning (yes/no)'
+  <&2 echo 'SRSNO         Spatial reference system number (SRID)'
+  <&2 echo 'GMLSRSNAME    SRSName to be used in GML exports'
+  <&2 echo
   
-  # to lower case
-  VERSIONING=$(echo "$VERSIONING" | awk '{print tolower($0)}')
+else 
+  # Parse args ----------------------------------------------------------------
+  # $1 = HOST
+  # $2 = PORT
+  # $3 = SID
+  # $4 = USERNAME
+  # $5 = PASSWORD
+  # $6 = DBVERSION
+  # $7 = VERSIONING
+  # $8 = SRSNO
+  # $9 = GMLSRSNAME
+
+  HOST=$1
+  PORT=$2
+  SID=$3
+  USERNAME=$4
+  PASSWORD=$5
+  DBVERSION=$6
+  VERSIONING=$7
+  SRSNO=$8
+  GMLSRSNAME=$9
   
-  if [  "$VERSIONING" = "yes" ] || [ "$VERSIONING" = "no" ] ; then
-    break;
-  else 
-    echo "Illegal input! Enter yes or no."  
-  fi
-done
-
-# Prompt for SRSNO ------------------------------------------------------------
-re='^[0-9]+$'
-while [ 1 ]; do
-  echo
-  echo 'Please enter a valid SRID (e.g. Berlin: 81989002): Press ENTER to use default.'
-  read -p "(default SRID=81989002): " SRSNO
-  SRSNO=${SRSNO:-81989002}
-  
-  if [[ ! $SRSNO =~ $re ]]; then
-    echo 'SRID must be numeric. Please retry.'
-  else 
-    break;
-  fi
-done
-
-# Prompt for GMLSRSNAME -------------------------------------------------------
-echo
-echo 'Please enter the corresponding SRSName to be used in GML exports. Press ENTER to use default.'
-read -p '(default GMLSRSNAME=urn:ogc:def:crs,crs:EPSG:6.12:3068,crs:EPSG:6.12:5783): ' GMLSRSNAME
-GMLSRSNAME=${GMLSRSNAME:-urn:ogc:def:crs,crs:EPSG:6.12:3068,crs:EPSG:6.12:5783}
-
-# Run CREATE_DB.sql to create the 3D City Database instance -------------------
-sqlplus "${USERNAME}@\"${HOST}:${PORT}/${SID}\"" @CREATE_DB.sql "${SRSNO}" "${GMLSRSNAME}" "${VERSIONING}" "${DBVERSION}"
-
-echo
-echo 'Press ENTER to quit.'
-read
+  # Run CREATE_DB.sql to create the 3D City Database instance -----------------
+  sqlplus "${USERNAME}/\"${PASSWORD}\"@\"${HOST}:${PORT}/${SID}\"" @CREATE_DB.sql "${SRSNO}" "${GMLSRSNAME}" "${VERSIONING}" "${DBVERSION}"
+fi

--- a/Oracle/SQLScripts/DROP_DB.bat
+++ b/Oracle/SQLScripts/DROP_DB.bat
@@ -12,10 +12,15 @@ set USERNAME=your_username
 
 :: add sqlplus to PATH
 set PATH=%SQLPLUSBIN%;%PATH%
-
 :: cd to path of the shell script
 cd /d %~dp0
 
+:: Interactive mode or usage with arguments? ----------------------------------
+if NOT [%1]==[] (
+  GOTO:args
+)
+
+:: INTERACTIVE MODE -----------------------------------------------------------
 :: Prompt for DBVERSION -------------------------------------------------------
 :dbversion
 set var=
@@ -39,5 +44,49 @@ IF "%res%"=="f" (
 
 :: Run DROP_DB.sql to drop the 3D City Database instance ----------------------
 sqlplus "%USERNAME%@\"%HOST%:%PORT%/%SID%\"" @DROP_DB.sql "%DBVERSION%"
+GOTO:EOF
 
-pause
+:: Correct number of args supplied? -------------------------------------------
+:args
+set argC=0
+for %%x in (%*) do Set /A argC+=1
+
+if NOT %argC% EQU 6 (
+  echo ERROR: Invalid number of arguments. 1>&2
+  call :usage
+  GOTO:EOF
+)
+
+:: Parse args -----------------------------------------------------------------
+:: %1 = HOST
+:: %2 = PORT
+:: %3 = SID
+:: %4 = USERNAME
+:: %5 = PASSWORD
+:: %6 = DBVERSION
+
+set HOST=%1
+set PORT=%2
+set SID=%3
+set USERNAME=%4
+set PASSWORD=%5
+set DBVERSION=%6
+
+:: Run CREATE_DB.sql to create the 3D City Database instance ------------------
+sqlplus "%USERNAME%/\"%PASSWORD%\"@\"%HOST%:%PORT%/%SID%\"" @DROP_DB.sql "%DBVERSION%"
+GOTO:EOF
+
+:: Print usage information ----------------------------------------------------
+:usage
+echo. 1<&2
+echo Usage: %~n0%~x0 HOST PORT SID USERNAME PASSWORD DBVERSION 1>&2
+echo No args can be ommitted and the order is mandatory. 1>&2
+echo. 1>&2
+echo HOST          Database host 1>&2
+echo PORT          Database port 1>&2
+echo SID           Database sid 1>&2
+echo USERNAME      Database username 1>&2
+echo PASSWORD      Database password 1>&2
+echo DBVERSION     Database license type, Oracle (S)patial or Oracle (L)ocator (S/L) 1>&2
+echo. 1>&2
+GOTO:EOF

--- a/Oracle/SQLScripts/DROP_DB.sh
+++ b/Oracle/SQLScripts/DROP_DB.sh
@@ -12,31 +12,62 @@ export USERNAME=your_username
 
 # add sqlplus to PATH
 PATH=$SQLPLUSBIN:$PATH
-
 # cd to path of the shell script
 cd "$( cd "$( dirname "$0" )" && pwd )" > /dev/null
 
-# Prompt for DBVERSION --------------------------------------------------------
-test=0
-while [ "$test" = "0" ]; do
-  echo
-  echo 'Which database license are you using? (Oracle Spatial(S)/Oracle Locator(L)): Press ENTER to use default.'
-  read -p "(default DBVERSION=Oracle Spatial(S)): " DBVERSION
-  DBVERSION=${DBVERSION:-S}
- 
- # to upper case
-  DBVERSION=$(echo "$DBVERSION" | awk '{print toupper($0)}')
+# Interactive mode or usage with arguments? -----------------------------------
+if [ $# -eq 0 ]; then
+  # INTERACTIVE MODE ----------------------------------------------------------
+  # Prompt for DBVERSION ------------------------------------------------------
+  while [ 1 ]; do
+    echo
+    echo 'Which database license are you using? (Oracle Spatial(S)/Oracle Locator(L)): Press ENTER to use default.'
+    read -p "(default DBVERSION=Oracle Spatial(S)): " DBVERSION
+    DBVERSION=${DBVERSION:-S}
   
-  if [ "$DBVERSION" = "S" ] || [ "$DBVERSION" = "L" ] ; then
-    test=1
-  else 
-    echo "Illegal input! Enter S or L."
-  fi
-done
+  # to upper case
+    DBVERSION=$(echo "$DBVERSION" | awk '{print toupper($0)}')
+    
+    if [ "$DBVERSION" = "S" ] || [ "$DBVERSION" = "L" ] ; then
+      break;
+    else 
+      echo "Illegal input! Enter S or L."
+    fi
+  done
+  
+  # Run DROP_DB.sql to drop the 3D City Database instance ---------------------
+  sqlplus "${USERNAME}@\"${HOST}:${PORT}/${SID}\"" @DROP_DB.sql "${DBVERSION}"
 
-# Run DROP_DB.sql to drop the 3D City Database instance -----------------------
-sqlplus "${USERNAME}@\"${HOST}:${PORT}/${SID}\"" @DROP_DB.sql "${DBVERSION}"
+elif [ $# -ne 6 ]; then
+  # Correct number of args supplied? ------------------------------------------
+  >&2 echo 'ERROR: Invalid number of arguments.'
+  >&2 echo
+  <&2 echo "Usage: $(basename "$0") HOST PORT SID USERNAME PASSWORD DBVERSION"
+  <&2 echo 'No args can be ommitted and the order is mandatory.'
+  <&2 echo
+  <&2 echo 'HOST          Database host'
+  <&2 echo 'PORT          Database port'
+  <&2 echo 'SID           Database sid'
+  <&2 echo 'USERNAME      Database username'
+  <&2 echo 'PASSWORD      Database password'
+  <&2 echo 'DBVERSION     Database license type, Oracle (S)patial or Oracle (L)ocator (S/L)'
+  <&2 echo
+else 
+  # Parse args ----------------------------------------------------------------
+  # $1 = HOST
+  # $2 = PORT
+  # $3 = SID
+  # $4 = USERNAME
+  # $5 = PASSWORD
+  # $6 = DBVERSION
 
-echo
-echo 'Press ENTER to quit.'
-read
+  HOST=$1
+  PORT=$2
+  SID=$3
+  USERNAME=$4
+  PASSWORD=$5
+  DBVERSION=$6
+  
+  # Run CREATE_DB.sql to create the 3D City Database instance -----------------
+  sqlplus "${USERNAME}/\"${PASSWORD}\"@\"${HOST}:${PORT}/${SID}\"" @DROP_DB.sql "${DBVERSION}"
+fi

--- a/PostgreSQL/SQLScripts/CREATE_DB.bat
+++ b/PostgreSQL/SQLScripts/CREATE_DB.bat
@@ -12,10 +12,15 @@ set PGUSER=your_username
 
 :: add PGBIN to PATH
 set PATH=%PGBIN%;%PATH%
-
 :: cd to path of the shell script
 cd /d %~dp0
 
+:: Interactive mode or usage with arguments? ----------------------------------
+if NOT [%1]==[] (
+  GOTO:args
+)
+
+:: INTERACTIVE MODE -----------------------------------------------------------
 :: Prompt for SRSNO -----------------------------------------------------------
 :srid
 set var=
@@ -50,5 +55,57 @@ IF /i NOT "%var%"=="" (
 
 :: Run CREATE_DB.sql to create the 3D City Database instance ------------------
 psql -d "%CITYDB%" -f "CREATE_DB.sql" -v srsno="%SRSNO%" -v gmlsrsname="%GMLSRSNAME%"
+GOTO:EOF
 
-pause
+:: Correct number of args supplied? -------------------------------------------
+:args
+set argC=0
+for %%x in (%*) do Set /A argC+=1
+
+if NOT %argC% EQU 7 (
+  echo ERROR: Invalid number of arguments. 1>&2
+  call :usage
+  GOTO:EOF
+)
+
+:: Parse args -----------------------------------------------------------------
+:: %1 = HOST
+:: %2 = PORT
+:: %3 = CITYDB
+:: %4 = USERNAME
+:: %5 = PASSWORD
+:: %6 = SRSNO
+:: %7 = GMLSRSNAME
+
+set HOST=%1
+set PORT=%2
+set CITYDB=%3
+set USERNAME=%4
+set PASSWORD=%5
+set SRSNO=%6
+set GMLSRSNAME=%7
+
+:: Run CREATE_DB.sql to create the 3D City Database instance ------------------
+set PGHOST=%HOST%
+set PGPORT=%PORT%
+set PGUSER=%USERNAME%
+set PGPASSWORD=%PASSWORD%
+
+psql -d "%CITYDB%" -f "CREATE_DB.sql" -v srsno="%SRSNO%" -v gmlsrsname="%GMLSRSNAME%"
+GOTO:EOF
+
+:: Print usage information ----------------------------------------------------
+:usage
+echo. 1<&2
+echo Usage: %~n0%~x0 HOST PORT CITYDB USERNAME PASSWORD SRSNO GMLSRSNAME 1>&2
+echo No args can be ommitted and the order is mandatory. 1>&2
+echo. 1>&2
+echo HOST          Database host 1>&2
+echo PORT          Database port 1>&2
+echo CITYDB        Database name 1>&2
+echo USERNAME      Database username 1>&2
+echo PASSWORD      Database password 1>&2
+echo SRSNO         Spatial reference system number (SRID) 1>&2
+echo GMLSRSNAME    SRSName to be used in GML exports 1>&2
+echo. 1>&2
+GOTO:EOF

--- a/PostgreSQL/SQLScripts/CREATE_DB.sh
+++ b/PostgreSQL/SQLScripts/CREATE_DB.sh
@@ -12,34 +12,76 @@ export PGUSER=your_username
 
 # add psql to PATH
 PATH=$PGBIN:$PATH
-
 # cd to path of the shell script
 cd "$( cd "$( dirname "$0" )" && pwd )" > /dev/null
 
-# Prompt for SRSNO ------------------------------------------------------------
-re='^[0-9]+$'
-while [ 1 ]; do
+# Interactive mode or usage with arguments? -----------------------------------
+if [ $# -eq 0 ]; then
+  # INTERACTIVE MODE ----------------------------------------------------------
+  # Prompt for SRSNO ----------------------------------------------------------
+  re='^[0-9]+$'
+  while [ 1 ]; do
+    echo
+    echo 'Please enter a valid SRID (e.g., 3068 for DHDN/Soldner Berlin): Press ENTER to use default.'
+    read -p "(default SRID=3068): " SRSNO
+    SRSNO=${SRSNO:-3068}
+    
+    if [[ ! $SRSNO =~ $re ]]; then
+      echo 'SRID must be numeric. Please retry.'
+    else 
+      break;
+    fi
+  done
+  
+  # Prompt for GMLSRSNAME -----------------------------------------------------
   echo
-  echo 'Please enter a valid SRID (e.g., 3068 for DHDN/Soldner Berlin): Press ENTER to use default.'
-  read -p "(default SRID=3068): " SRSNO
-  SRSNO=${SRSNO:-3068}
-   
-  if [[ ! $SRSNO =~ $re ]]; then
-    echo 'SRID must be numeric. Please retry.'
-  else 
-    break;
-  fi
-done
+  echo 'Please enter the corresponding SRSName to be used in GML exports. Press ENTER to use default.'
+  read -p '(default GMLSRSNAME=urn:ogc:def:crs,crs:EPSG:6.12:3068,crs:EPSG:6.12:5783): ' GMLSRSNAME
+  GMLSRSNAME=${GMLSRSNAME:-urn:ogc:def:crs,crs:EPSG:6.12:3068,crs:EPSG:6.12:5783}
+  
+  # Run CREATE_DB.sql to create the 3D City Database instance -----------------
+  psql -d "$CITYDB" -f "CREATE_DB.sql" -v srsno="$SRSNO" -v gmlsrsname="$GMLSRSNAME"
+  
+elif [ $# -ne 7 ]; then
+  # Correct number of args supplied? ------------------------------------------
+  >&2 echo 'ERROR: Invalid number of arguments.'
+  >&2 echo
+  <&2 echo "Usage: $(basename "$0") HOST PORT CITYDB USERNAME PASSWORD SRSNO GMLSRSNAME"
+  <&2 echo 'No args can be ommitted and the order is mandatory.'
+  <&2 echo
+  <&2 echo 'HOST          Database host'
+  <&2 echo 'PORT          Database port'
+  <&2 echo 'CITYDB        Database name'
+  <&2 echo 'USERNAME      Database username'
+  <&2 echo 'PASSWORD      Database password'
+  <&2 echo 'SRSNO         Spatial reference system number (SRID)'
+  <&2 echo 'GMLSRSNAME    SRSName to be used in GML exports'
+  <&2 echo
+  
+else 
+  # Parse args ----------------------------------------------------------------
+  # $1 = HOST
+  # $2 = PORT
+  # $3 = CITYDB
+  # $4 = USERNAME
+  # $5 = PASSWORD
+  # $6 = SRSNO
+  # $7 = GMLSRSNAME
 
-# Prompt for GMLSRSNAME -------------------------------------------------------
-echo
-echo 'Please enter the corresponding SRSName to be used in GML exports. Press ENTER to use default.'
-read -p '(default GMLSRSNAME=urn:ogc:def:crs,crs:EPSG:6.12:3068,crs:EPSG:6.12:5783): ' GMLSRSNAME
-GMLSRSNAME=${GMLSRSNAME:-urn:ogc:def:crs,crs:EPSG:6.12:3068,crs:EPSG:6.12:5783}
-
-# Run CREATE_DB.sql to create the 3D City Database instance -------------------
-psql -d "$CITYDB" -f "CREATE_DB.sql" -v srsno="$SRSNO" -v gmlsrsname="$GMLSRSNAME"
-
-echo
-echo 'Press ENTER to quit.'
-read
+  HOST=$1
+  PORT=$2
+  CITYDB=$3
+  USERNAME=$4
+  PASSWORD=$5
+  export SRSNO=$6
+  export GMLSRSNAME=$7
+  
+  # Run CREATE_DB.sql to create the 3D City Database instance -----------------
+  export PGHOST=$HOST
+  export PGPORT=$PORT
+  export PGUSER=$USERNAME
+  export PGPASSWORD=$PASSWORD
+  
+  psql -d "$CITYDB" -f "CREATE_DB.sql" -v srsno="$SRSNO" -v gmlsrsname="$GMLSRSNAME"
+fi
+  

--- a/PostgreSQL/SQLScripts/DROP_DB.bat
+++ b/PostgreSQL/SQLScripts/DROP_DB.bat
@@ -12,11 +12,61 @@ set PGUSER=your_username
 
 :: add PGBIN to PATH
 set PATH=%PGBIN%;%PATH%
-
 :: cd to path of the shell script
 cd /d %~dp0
 
+:: Interactive mode or usage with arguments? ----------------------------------
+if NOT [%1]==[] (
+  GOTO:args
+)
+
 REM Run DROP_DB.sql to drop the 3D City Database instance ---------------------
 psql -d "%CITYDB%" -f "DROP_DB.sql"
+GOTO:EOF
 
-pause
+:: Correct number of args supplied? -------------------------------------------
+:args
+set argC=0
+for %%x in (%*) do Set /A argC+=1
+
+if NOT %argC% EQU 5 (
+  echo ERROR: Invalid number of arguments. 1>&2
+  call :usage
+  GOTO:EOF
+)
+
+:: Parse args -----------------------------------------------------------------
+:: %1 = HOST
+:: %2 = PORT
+:: %3 = CITYDB
+:: %4 = USERNAME
+:: %5 = PASSWORD
+
+set HOST=%1
+set PORT=%2
+set CITYDB=%3
+set USERNAME=%4
+set PASSWORD=%5
+
+:: Run CREATE_DB.sql to create the 3D City Database instance ------------------
+set PGHOST=%HOST%
+set PGPORT=%PORT%
+set PGUSER=%USERNAME%
+set PGPASSWORD=%PASSWORD%
+
+psql -d "%CITYDB%" -f "DROP_DB.sql"
+GOTO:EOF
+
+:: Print usage information ----------------------------------------------------
+:usage
+echo. 1<&2
+echo Usage: %~n0%~x0 HOST PORT CITYDB USERNAME PASSWORD 1>&2
+echo No args can be ommitted and the order is mandatory. 1>&2
+echo. 1>&2
+echo HOST          Database host 1>&2
+echo PORT          Database port 1>&2
+echo CITYDB        Database name 1>&2
+echo USERNAME      Database username 1>&2
+echo PASSWORD      Database password 1>&2
+echo. 1>&2
+GOTO:EOF

--- a/PostgreSQL/SQLScripts/DROP_DB.sh
+++ b/PostgreSQL/SQLScripts/DROP_DB.sh
@@ -12,13 +12,48 @@ export PGUSER=your_username
 
 # add psql to PATH
 PATH=$PGBIN:$PATH
-
 # cd to path of the shell script
 cd "$( cd "$( dirname "$0" )" && pwd )" > /dev/null
 
-# Run DROP_DB.sql to drop the 3D City Database instance -----------------------
-psql -d "$CITYDB" -f "DROP_DB.sql"
+# Interactive mode or usage with arguments? -----------------------------------
+if [ $# -eq 0 ]; then
+  # INTERACTIVE MODE ----------------------------------------------------------
+  # Run DROP_DB.sql to drop the 3D City Database instance -----------------------
+  psql -d "$CITYDB" -f "DROP_DB.sql"
 
-echo
-echo 'Press ENTER to quit.'
-read
+  elif [ $# -ne 5 ]; then
+  # Correct number of args supplied? ------------------------------------------
+  >&2 echo 'ERROR: Invalid number of arguments.'
+  >&2 echo
+  <&2 echo "Usage: $(basename "$0") HOST PORT CITYDB USERNAME PASSWORD"
+  <&2 echo 'No args can be ommitted and the order is mandatory.'
+  <&2 echo
+  <&2 echo 'HOST          Database host'
+  <&2 echo 'PORT          Database port'
+  <&2 echo 'CITYDB        Database name'
+  <&2 echo 'USERNAME      Database username'
+  <&2 echo 'PASSWORD      Database password'
+  <&2 echo
+  
+else 
+  # Parse args ----------------------------------------------------------------
+  # $1 = HOST
+  # $2 = PORT
+  # $3 = CITYDB
+  # $4 = USERNAME
+  # $5 = PASSWORD
+
+  HOST=$1
+  PORT=$2
+  CITYDB=$3
+  USERNAME=$4
+  PASSWORD=$5
+  
+  # Run CREATE_DB.sql to create the 3D City Database instance -----------------
+  export PGHOST=$HOST
+  export PGPORT=$PORT
+  export PGUSER=$USERNAME
+  export PGPASSWORD=$PASSWORD
+  
+  psql -d "$CITYDB" -f "DROP_DB.sql"
+fi


### PR DESCRIPTION
Introduce ability to pass arguments to the setup scripts for better automation of 3DCityDB instance creation. For instance:
```cmd
Usage: CREATE_DB.bat HOST PORT SID USERNAME PASSWORD DBVERSION VERSIONING SRSNO GMLSRSNAME
No args can be ommitted and the order is mandatory.

HOST          Database host
PORT          Database port
SID           Database sid
USERNAME      Database username
PASSWORD      Database password
DBVERSION     Database license type, Oracle (S)patial or Oracle (L)ocator (S/L)
VERSIONING    Enable database versioning (yes/no)
SRSNO         Spatial reference system number (SRID)
GMLSRSNAME    SRSName to be used in GML exports
```