### PR TITLE
fixed citydb_pkg.set_enabled_geom_fkeys

### DIFF
--- a/PostgreSQL/SQLScripts/CITYDB_PKG/CONSTRAINT/CONSTRAINT.sql
+++ b/PostgreSQL/SQLScripts/CITYDB_PKG/CONSTRAINT/CONSTRAINT.sql
@@ -174,16 +174,12 @@ SELECT
 FROM
   pg_constraint c
 JOIN
-  pg_namespace n
-  ON n.oid = c.connamespace
-JOIN
   pg_trigger t
   ON t.tgconstraint = c.oid
 WHERE
   c.contype = 'f'
-  AND c.confrelid = 'surface_geometry'::regclass::oid
+  AND c.confrelid = (lower($2) || '.surface_geometry')::regclass::oid
   AND c.confdeltype <> 'c'
-  AND n.nspname = $2;
 $$
 LANGUAGE sql STRICT;
 


### PR DESCRIPTION
This PR tries to fix the issue reported here #40. 

The function `set_enabled_geom_fkeys` could also somehow be simplified by removing the database join with the `pg_namespace` table 