### PR TITLE
Fix change_schema_srid function

### DIFF
--- a/oracle/SQLScripts/CITYDB_PKG/CONSTRAINT/CONSTRAINT.sql
+++ b/oracle/SQLScripts/CITYDB_PKG/CONSTRAINT/CONSTRAINT.sql
@@ -342,7 +342,7 @@ AS
         set_column_sdo_metadata(rec.c, 3, schema_srid, rec.t, schema_name);
       END IF;
     END LOOP;
-    dbms_output.put_line('Spatial metadata sucessfully set for ' || schema_name);
+    dbms_output.put_line('Spatial metadata successfully set for ' || schema_name);
   END;
 
 END citydb_constraint;

--- a/oracle/SQLScripts/CITYDB_PKG/SRS/SRS.sql
+++ b/oracle/SQLScripts/CITYDB_PKG/SRS/SRS.sql
@@ -281,7 +281,8 @@ AS
     END IF;
 
     -- update entry in DATABASE_SRS table first
-    EXECUTE IMMEDIATE 'UPDATE database_srs SET srid = :1, gml_srs_name = :2' USING schema_srid, schema_gml_srs_name;
+    EXECUTE IMMEDIATE 'TRUNCATE TABLE database_srs';
+    EXECUTE IMMEDIATE 'INSERT INTO database_srs (srid, gml_srs_name) VALUES (:1, :2)' USING schema_srid, schema_gml_srs_name;
 
     -- change srid of spatial columns in given schema
     FOR rec IN (

--- a/postgresql/SQLScripts/CITYDB_PKG/SRS/SRS.sql
+++ b/postgresql/SQLScripts/CITYDB_PKG/SRS/SRS.sql
@@ -228,7 +228,8 @@ BEGIN
   PERFORM citydb_pkg.check_srid($1);
 
   -- update entry in database_srs table first
-  EXECUTE format('UPDATE %I.database_srs SET srid = %L, gml_srs_name = %L', $4, $1, $2);
+  EXECUTE format('TRUNCATE TABLE %I.database_srs', $4);
+  EXECUTE format('INSERT INTO %I.database_srs (srid, gml_srs_name) VALUES (%L, %L)', $4, $1, $2);
 
   -- change srid of spatial columns in given schema
   PERFORM citydb_pkg.change_column_srid(f_table_name, f_geometry_column, coord_dimension, $1, $3, type, f_table_schema)

--- a/postgresql/SQLScripts/CREATE_DB.sql
+++ b/postgresql/SQLScripts/CREATE_DB.sql
@@ -97,6 +97,5 @@ ALTER DATABASE :"DBNAME" SET search_path TO citydb, citydb_pkg, :current_path;
 SELECT citydb_pkg.check_srid(:SRSNO);
 
 \echo 'Setting spatial reference system of 3DCityDB instance ...'
-INSERT INTO citydb.DATABASE_SRS(SRID,GML_SRS_NAME) VALUES (0,'init');
 SELECT citydb_pkg.change_schema_srid(:SRSNO,:'GMLSRSNAME');
 \echo 'Done'

--- a/postgresql/SQLScripts/UTIL/SCHEMAS/CREATE_SCHEMA.sql
+++ b/postgresql/SQLScripts/UTIL/SCHEMAS/CREATE_SCHEMA.sql
@@ -69,6 +69,5 @@ SELECT version as citydb_version from citydb_pkg.citydb_version();
 
 \echo 'Setting spatial reference system for schema "':SCHEMA_NAME'" (will be the same as for schema "citydb") ...'
 \set SCHEMA_NAME_QUOTED '\'':SCHEMA_NAME'\''
-INSERT INTO :SCHEMA_NAME.DATABASE_SRS(SRID,GML_SRS_NAME) VALUES (0,'init');
 SELECT citydb_pkg.change_schema_srid(database_srs.srid, database_srs.gml_srs_name, 0, :SCHEMA_NAME_QUOTED) FROM citydb.database_srs LIMIT 1;
 \echo 'Done'


### PR DESCRIPTION
This PR solves https://github.com/3dcitydb/3dcitydb/issues/67.

I simplified the `change_schema_srid` function by removing some tests that prevented to apply the new SRID in case it matched the SRID stored in `database_srs`. This behaviour could quickly lead to inconsistencies and unexpected behaviour as the one reported in https://github.com/3dcitydb/3dcitydb/issues/67.

The `change_schema_srid` function now always applies the SRID. Whether changing the SRID is required must be checked outside the function.

