### PR TITLE
[PostgreSQL] Run `VACUUM ANALYZE` after DB migration or upgrade

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,8 @@ Change Log
 ### 4.3.0 - tba
 
 ##### Changes
-* The `VACUUM_SPATIAL_COLUMNS.sql` has been simplified and now also works for ADE tables. [#77](https://github.com/3dcitydb/3dcitydb/pull/77)
+* PostgreSQL: Run `VACUUM ANALYZE` after DB migration or upgrade.
+* PostgreSQL: The `VACUUM_SPATIAL_COLUMNS.sql` has been simplified and now also works for ADE tables. [#77](https://github.com/3dcitydb/3dcitydb/pull/77)
 * Added two new columns `GMLID` and `GMLID_CODESPACE` to the `IMPLICIT_GEOMETRY` table. [#79](https://github.com/3dcitydb/3dcitydb/pull/79)
 
 ##### Fixes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Change Log
 ### 4.3.0 - tba
 
 ##### Changes
-* PostgreSQL: Run `VACUUM ANALYZE` after DB migration or upgrade.
+* PostgreSQL: Run `VACUUM ANALYZE` after DB migration or upgrade. [#87](https://github.com/3dcitydb/3dcitydb/pull/87)
 * PostgreSQL: The `VACUUM_SPATIAL_COLUMNS.sql` has been simplified and now also works for ADE tables. [#77](https://github.com/3dcitydb/3dcitydb/pull/77)
 * Added two new columns `GMLID` and `GMLID_CODESPACE` to the `IMPLICIT_GEOMETRY` table. [#79](https://github.com/3dcitydb/3dcitydb/pull/79)
 

--- a/postgresql/SQLScripts/MIGRATION/UTIL/VACUUM.sql
+++ b/postgresql/SQLScripts/MIGRATION/UTIL/VACUUM.sql
@@ -1,0 +1,30 @@
+-- noinspection SqlDialectInspectionForFile
+
+-- 3D City Database - The Open Source CityGML Database
+-- https://www.3dcitydb.org/
+--
+-- Copyright 2013 - 2021
+-- Chair of Geoinformatics
+-- Technical University of Munich, Germany
+-- https://www.lrg.tum.de/gis/
+--
+-- The 3D City Database is jointly developed with the following
+-- cooperation partners:
+--
+-- Virtual City Systems, Berlin <https://vc.systems/>
+-- M.O.S.S. Computer Grafik Systeme GmbH, Taufkirchen <http://www.moss.de/>
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+VACUUM ANALYZE;

--- a/postgresql/SQLScripts/MIGRATION/V2_to_V4/MIGRATE_DB.sql
+++ b/postgresql/SQLScripts/MIGRATION/V2_to_V4/MIGRATE_DB.sql
@@ -86,6 +86,11 @@ CREATE SCHEMA citydb_pkg;
 \echo 'Update indexes ...'
 \ir INDEXES.sql
 
+--// do VACUUM
+\echo
+\echo 'Do VACUUM ...'
+\ir ../UTIL/VACUUM.sql
+
 --// removing v2.x schema (if the user wants to)
 --\echo
 --\echo 'Removing database elements of 3DCityDB v2.x schema ...'

--- a/postgresql/SQLScripts/MIGRATION/V3_to_V4/MIGRATE_DB.sql
+++ b/postgresql/SQLScripts/MIGRATION/V3_to_V4/MIGRATE_DB.sql
@@ -101,5 +101,10 @@ CREATE SCHEMA citydb_pkg;
 \echo 'Do bigint update ...'
 \ir ../UTIL/BIGINT.sql
 
+--// do VACUUM
+\echo
+\echo 'Do VACUUM ...'
+\ir ../UTIL/VACUUM.sql
+
 \echo
 \echo '3DCityDB migration complete!'

--- a/postgresql/SQLScripts/MIGRATION/V4_UPGRADE/DO_UPGRADE.sql
+++ b/postgresql/SQLScripts/MIGRATION/V4_UPGRADE/DO_UPGRADE.sql
@@ -95,3 +95,8 @@ $$;
 \echo
 \echo 'Do bigint update ...'
 \ir ../UTIL/BIGINT.sql
+
+--// do VACUUM
+\echo
+\echo 'Do VACUUM ...'
+\ir ../UTIL/VACUUM.sql


### PR DESCRIPTION
Some users reported that the CityGML import, export, and delete become slower after database upgrade, especially after upgrading the DB to v4.2 to use PostgreSQL BIGINT.  This performance issue can be solved by running `VACUUM ANALYZE`. This PR extends the upgrade and migration scripts to run the command automatically. 