### PR TITLE
Docker image for 3DCityDB v5

### DIFF
--- a/.github/workflows/psql-docker-build-push-edge-v5.yml
+++ b/.github/workflows/psql-docker-build-push-edge-v5.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
     - v5-devel
-    - v5-docker
 
 env:
   IMAGE_NAME: 3dcitydb-pg-v5
@@ -60,7 +59,7 @@ jobs:
           latest=false
           suffix=${{ matrix.variant }}
         tags: |
-          type=edge,branch=v5-docker
+          type=edge,branch=v5-devel
         labels: |
           maintainer=Bruno Willenborg
           maintainer.email=b.willenborg(at)tum.de

--- a/.github/workflows/psql-docker-build-push-edge-v5.yml
+++ b/.github/workflows/psql-docker-build-push-edge-v5.yml
@@ -60,7 +60,7 @@ jobs:
           latest=false
           suffix=${{ matrix.variant }}
         tags: |
-          type=edge,branch=master
+          type=edge,branch=v5-devel
         labels: |
           maintainer=Bruno Willenborg
           maintainer.email=b.willenborg(at)tum.de

--- a/.github/workflows/psql-docker-build-push-edge-v5.yml
+++ b/.github/workflows/psql-docker-build-push-edge-v5.yml
@@ -1,0 +1,94 @@
+name: psql-docker-build-push-edge-v5
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+    - v5-devel
+
+env:
+  IMAGE_NAME=3dcitydb-pg-v5
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        baseimage-tag: ['16-3.4']   # base image tags for 'edge' image
+        variant: ['', '-alpine']    # image variants: '' = debian
+
+    steps:
+    -
+      name: Parse short sha
+      uses: benjlevesque/short-sha@v2.2
+      id: short-sha
+    -
+      name: set lower case owner name
+      run: |
+        echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}
+      env:
+        OWNER: '${{ github.repository_owner }}'
+    -
+      name: Checkout repo
+      uses: actions/checkout@v4
+    -
+      name: Docker login Dockerhub
+      id: docker_login
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+    -
+      name: Login to GitHub Container Registry
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    -
+      name: Extract metadata (tags, labels) for docker image
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: |
+          ${{ env.OWNER_LC }}/${{ env.IMAGE_NAME }}
+          ghcr.io/${{ env.OWNER_LC }}/${{ env.IMAGE_NAME }}
+        flavor: |
+          latest=false
+          suffix=${{ matrix.variant }}
+        tags: |
+          type=edge,branch=master
+        labels: |
+          maintainer=Bruno Willenborg
+          maintainer.email=b.willenborg(at)tum.de
+          maintainer.organization=Chair of Geoinformatics, Technical University of Munich (TUM)
+          org.opencontainers.image.authors=Bruno Willenborg
+          org.opencontainers.image.vendor=3DCityDB Steering Committee
+          org.opencontainers.image.title=3D City Database PostgreSQL/PostGIS Docker image
+          org.opencontainers.image.description=Docker image for the 3D City Database based on PostgreSQL and PostGIS
+          org.opencontainers.image.url=https://github.com/3dcitydb/
+          org.opencontainers.image.documentation=https://3dcitydb-docs.readthedocs.io/en/latest/3dcitydb/docker.html
+          org.opencontainers.image.source=https://github.com/3dcitydb/3dcitydb
+    -
+      name: Build and push image
+      id: docker_build
+      uses: docker/build-push-action@v5
+      with:
+        context: ./postgresql
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        build-args: |
+          BASEIMAGE_TAG=${{ matrix.baseimage-tag }}${{ matrix.variant }}
+          CITYDB_VERSION=${{ steps.short-sha.outputs.sha }}
+    -
+      name: Image digest
+      run: echo ${{ steps.docker_build.outputs.digest }}
+    -
+      name: Inspect image Dockerhub
+      run: docker inspect ${{ env.OWNER_LC }}/${{ env.IMAGE_NAME }}:edge${{ matrix.variant }}
+    -
+      name: Inspect image ghcr.io
+      run: docker inspect ghcr.io/${{ env.OWNER_LC }}/${{ env.IMAGE_NAME }}:edge${{ matrix.variant }}

--- a/.github/workflows/psql-docker-build-push-edge-v5.yml
+++ b/.github/workflows/psql-docker-build-push-edge-v5.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
     - v5-devel
+    - v5-docker
 
 env:
   IMAGE_NAME=3dcitydb-pg-v5

--- a/.github/workflows/psql-docker-build-push-edge-v5.yml
+++ b/.github/workflows/psql-docker-build-push-edge-v5.yml
@@ -8,7 +8,7 @@ on:
     - v5-docker
 
 env:
-  IMAGE_NAME=3dcitydb-pg-v5
+  IMAGE_NAME: 3dcitydb-pg-v5
 
 jobs:
   build:

--- a/.github/workflows/psql-docker-build-push-edge-v5.yml
+++ b/.github/workflows/psql-docker-build-push-edge-v5.yml
@@ -60,7 +60,7 @@ jobs:
           latest=false
           suffix=${{ matrix.variant }}
         tags: |
-          type=edge,branch=v5-devel
+          type=edge,branch=v5-docker
         labels: |
           maintainer=Bruno Willenborg
           maintainer.email=b.willenborg(at)tum.de

--- a/postgresql/DockerScripts/3dcitydb-initdb.sh
+++ b/postgresql/DockerScripts/3dcitydb-initdb.sh
@@ -58,23 +58,13 @@ fi
 
 # Add PostGIS SFCGAL extension ------------------------------------------------
 if [ ! -z ${POSTGIS_SFCGAL+x} ] && [ ${POSTGIS_SFCGAL} = true ] || [ "${POSTGIS_SFCGAL}" = "yes" ] ; then
-  # SFCGAL is currently not available in the post/postgis:alpine images.
-  # Test for Alpine Linux and warn if enabled and alpine image variant.
 
-  if grep -iq "alpine" /etc/os-release; then
-    echo
-    echo "!!! WARNING: POSTGIS_SFCGAL was set, but SFCGAL is not available on Alpine Linux image variants."
-    echo "!!! Please use the Debian based image variants if you require SFCGAL support."
-    SFCGAL=false
-  else
-    echo
-    echo "Create PostGIS SFCGAL extensions in database '$POSTGRES_DB' ..."
+  echo "Create PostGIS SFCGAL extensions in database '$POSTGRES_DB' ..."
 
-    "${psql[@]}" -d "$POSTGRES_DB" -c "CREATE EXTENSION IF NOT EXISTS postgis_sfcgal;"
+  "${psql[@]}" -d "$POSTGRES_DB" -c "CREATE EXTENSION IF NOT EXISTS postgis_sfcgal;"
 
-    echo "Create PostGIS SFCGAL extensions in database '$POSTGRES_DB' ...done!"
-    SFCGAL=true
-  fi
+  echo "Create PostGIS SFCGAL extensions in database '$POSTGRES_DB' ...done!"
+  SFCGAL=true
 else
   SFCGAL=false
 fi

--- a/postgresql/DockerScripts/3dcitydb-initdb.sh
+++ b/postgresql/DockerScripts/3dcitydb-initdb.sh
@@ -22,25 +22,25 @@ else
   fi
 fi
 
-# GMLSRSNAME  -----------------------------------------------------------------
-if [ -z ${GMLSRSNAME+x} ]; then
-  # GMLSRSNAME unset, set default GMLSRSNAME using HEIGHT_EPSG if set
+# SRSNAME ---------------------------------------------------------------------
+if [ -z ${SRSNAME+x} ]; then
+  # SRSNAME unset, set default SRSNAME using HEIGHT_EPSG if set
   # HEIGHT EPSG ---------------------------------------------------------------
   if [ -z ${HEIGHT_EPSG+x} ]; then
     # No HEIGHT_EPSG given
-    GMLSRSNAME="urn:ogc:def:crs:EPSG::$SRID"
+    SRSNAME="urn:ogc:def:crs:EPSG::$SRID"
   else
     if [ $HEIGHT_EPSG -gt 0 ]; then
-      GMLSRSNAME="urn:ogc:def:crs,crs:EPSG::$SRID,crs:EPSG::$HEIGHT_EPSG"
+      SRSNAME="urn:ogc:def:crs,crs:EPSG::$SRID,crs:EPSG::$HEIGHT_EPSG"
     else
-      GMLSRSNAME="urn:ogc:def:crs:EPSG::$SRID"
+      SRSNAME="urn:ogc:def:crs:EPSG::$SRID"
     fi
   fi
 else
   if [ ! -z ${HEIGHT_EPSG+x} ]; then
-    # GMLSRSNAME is set, HEIGHT_EPSG is ignored
+    # SRSNAME is set, HEIGHT_EPSG is ignored
     echo
-    echo "!!! WARNING: GMLSRSNAME is set. HEIGHT_EPSG will be ignored."
+    echo "!!! WARNING: SRSNAME is set. HEIGHT_EPSG will be ignored."
   fi
 fi
 
@@ -74,7 +74,7 @@ echo
 echo "Setting up 3DCityDB database schema in database '$POSTGRES_DB' ..."
 
 "${psql[@]}" -d "$POSTGRES_DB" -f "CREATE_DB.sql" \
-  -v srsno="$SRID" -v gmlsrsname="$GMLSRSNAME" > /dev/null
+  -v srsno="$SRID" -v gmlsrsname="$SRSNAME" > /dev/null
 
 echo "Setting up 3DCityDB database schema in database '$POSTGRES_DB' ...done!"
 
@@ -93,7 +93,7 @@ cat <<EOF
 #   3DCityDB version  $CITYDBVERSION
 #   DBNAME            $POSTGRES_DB
 #   SRID              $SRID
-#   SRSNAME           $GMLSRSNAME
+#   SRSNAME           $SRSNAME
 #   HEIGHT_EPSG       $HEIGHT_EPSG
 #   SFCGAL enabled    $SFCGAL
 #

--- a/postgresql/DockerScripts/3dcitydb-initdb.sh
+++ b/postgresql/DockerScripts/3dcitydb-initdb.sh
@@ -22,25 +22,25 @@ else
   fi
 fi
 
-# SRSNAME ---------------------------------------------------------------------
-if [ -z ${SRSNAME+x} ]; then
-  # SRSNAME unset, set default SRSNAME using HEIGHT_EPSG if set
+# SRS_NAME --------------------------------------------------------------------
+if [ -z ${SRS_NAME+x} ]; then
+  # SRS_NAME unset, set default SRS_NAME using HEIGHT_EPSG if set
   # HEIGHT EPSG ---------------------------------------------------------------
   if [ -z ${HEIGHT_EPSG+x} ]; then
     # No HEIGHT_EPSG given
-    SRSNAME="urn:ogc:def:crs:EPSG::$SRID"
+    SRS_NAME="urn:ogc:def:crs:EPSG::$SRID"
   else
     if [ $HEIGHT_EPSG -gt 0 ]; then
-      SRSNAME="urn:ogc:def:crs,crs:EPSG::$SRID,crs:EPSG::$HEIGHT_EPSG"
+      SRS_NAME="urn:ogc:def:crs,crs:EPSG::$SRID,crs:EPSG::$HEIGHT_EPSG"
     else
-      SRSNAME="urn:ogc:def:crs:EPSG::$SRID"
+      SRS_NAME="urn:ogc:def:crs:EPSG::$SRID"
     fi
   fi
 else
   if [ ! -z ${HEIGHT_EPSG+x} ]; then
-    # SRSNAME is set, HEIGHT_EPSG is ignored
+    # SRS_NAME is set, HEIGHT_EPSG is ignored
     echo
-    echo "!!! WARNING: SRSNAME is set. HEIGHT_EPSG will be ignored."
+    echo "!!! WARNING: SRS_NAME is set. HEIGHT_EPSG will be ignored."
   fi
 fi
 
@@ -74,7 +74,7 @@ echo
 echo "Setting up 3DCityDB database schema in database '$POSTGRES_DB' ..."
 
 "${psql[@]}" -d "$POSTGRES_DB" -f "CREATE_DB.sql" \
-  -v srsno="$SRID" -v gmlsrsname="$SRSNAME" > /dev/null
+  -v srsno="$SRID" -v gmlsrsname="$SRS_NAME" > /dev/null
 
 echo "Setting up 3DCityDB database schema in database '$POSTGRES_DB' ...done!"
 
@@ -93,7 +93,7 @@ cat <<EOF
 #   3DCityDB version  $CITYDBVERSION
 #   DBNAME            $POSTGRES_DB
 #   SRID              $SRID
-#   SRSNAME           $SRSNAME
+#   SRSNAME           $SRS_NAME
 #   HEIGHT_EPSG       $HEIGHT_EPSG
 #   SFCGAL enabled    $SFCGAL
 #


### PR DESCRIPTION
This PR adds an `edge` image for the 3DCityDB v5. The image is built from the latest commit to `v5-devel` branch and published to Dockerhub and Github packages:

- `3dcitydb/3dcitydb-pg-v5:edge`
- `ghcr.io/3dcitydb/3dcitydb-pg-v5:edge`

```shell
docker run --name 3dciytdb -p 5432:5432 -d \
    -e POSTGRES_PASSWORD=<theSecretPassword> \
    -e SRID=<EPSG code> \
    [-e HEIGHT_EPSG=<EPSG code>] \
    [-e SRS_NAME=<mySrsName>] \
    [-e POSTGRES_DB=<database name>] \
    [-e POSTGRES_USER=<username>] \
    [-e POSTGIS_SFCGAL=<true|false|yes|no>] \
  3dcitydb/3dcitydb-pg-v5:edge
```