### PR TITLE
Reworked "delete_property" function

### DIFF
--- a/postgresql/SQLScripts/CITYDB_PKG/DELETE/DELETE.sql
+++ b/postgresql/SQLScripts/CITYDB_PKG/DELETE/DELETE.sql
@@ -6,6 +6,7 @@
 * delete_feature(pid_array bigint[]) RETURNS SETOF BIGINT
 * delete_feature(pid_array bigint[], schema_name TEXT) RETURNS SETOF BIGINT
 * delete_feature(pid bigint, schema_name TEXT) RETURNS BIGINT
+* delete_property_row(pid_array bigint[]) RETURNS SETOF BIGINT
 * delete_property(pid_array bigint[]) RETURNS SETOF BIGINT
 * delete_property(pid_array bigint[], schema_name TEXT) RETURNS SETOF BIGINT
 * delete_property(pid bigint, schema_name TEXT) RETURNS BIGINT
@@ -131,9 +132,9 @@ $body$
 LANGUAGE plpgsql STRICT;
 
 /******************************************************************
-* delete from PROPERTY table based on an id array
+* delete single row from PROPERTY table based on an id array
 ******************************************************************/
-CREATE OR REPLACE FUNCTION citydb_pkg.delete_property(bigint[]) RETURNS SETOF BIGINT AS
+CREATE OR REPLACE FUNCTION citydb_pkg.delete_property_row(bigint[]) RETURNS SETOF BIGINT AS
 $body$
 DECLARE
   deleted_ids bigint[] := '{}';
@@ -219,6 +220,46 @@ BEGIN
 
   RETURN QUERY
     SELECT unnest(deleted_ids);
+END;
+$body$
+LANGUAGE plpgsql STRICT;
+
+/******************************************************************
+* delete from PROPERTY table based on an id array
+******************************************************************/
+CREATE OR REPLACE FUNCTION citydb_pkg.delete_property(bigint[]) RETURNS SETOF BIGINT AS
+$body$
+DECLARE
+  property_ids bigint[] := '{}';
+BEGIN
+  WITH RECURSIVE child_refs AS (
+    SELECT
+	  p.id
+	FROM
+	  property p,
+	  unnest($1) a(a_id)
+	WHERE
+	  p.id = a.a_id
+	UNION ALL
+	SELECT
+	  p.id
+	FROM
+	  property p,
+	  child_refs c
+	WHERE
+      p.parent_id = c.id
+  )
+  SELECT
+    array_agg(id)
+  INTO
+    property_ids
+  FROM
+    child_refs;
+
+  RETURN QUERY
+    SELECT citydb_pkg.delete_property_row(property_ids)
+	INTERSECT
+	SELECT unnest($1);
 END;
 $body$
 LANGUAGE plpgsql STRICT;

--- a/postgresql/SQLScripts/CITYDB_PKG/DELETE/DELETE.sql
+++ b/postgresql/SQLScripts/CITYDB_PKG/DELETE/DELETE.sql
@@ -71,7 +71,7 @@ DECLARE
   deleted_ids bigint[] := '{}';
 BEGIN
   PERFORM
-    citydb_pkg.delete_property(array_agg(p.id))
+    citydb_pkg.delete_property_row(array_agg(p.id))
   FROM
     property p,
     unnest($1) a(a_id)

--- a/postgresql/SQLScripts/CITYDB_PKG/DELETE/DELETE.sql
+++ b/postgresql/SQLScripts/CITYDB_PKG/DELETE/DELETE.sql
@@ -234,19 +234,19 @@ DECLARE
 BEGIN
   WITH RECURSIVE child_refs AS (
     SELECT
-	  p.id
-	FROM
-	  property p,
-	  unnest($1) a(a_id)
-	WHERE
-	  p.id = a.a_id
-	UNION ALL
-	SELECT
-	  p.id
-	FROM
-	  property p,
-	  child_refs c
-	WHERE
+      p.id
+    FROM
+      property p,
+      unnest($1) a(a_id)
+    WHERE
+      p.id = a.a_id
+    UNION ALL
+    SELECT
+      p.id
+    FROM
+      property p,
+      child_refs c
+    WHERE
       p.parent_id = c.id
   )
   SELECT
@@ -258,8 +258,8 @@ BEGIN
 
   RETURN QUERY
     SELECT citydb_pkg.delete_property_row(property_ids)
-	INTERSECT
-	SELECT unnest($1);
+    INTERSECT
+    SELECT unnest($1);
 END;
 $body$
 LANGUAGE plpgsql STRICT;

--- a/postgresql/SQLScripts/CITYDB_PKG/DELETE/DELETE.sql
+++ b/postgresql/SQLScripts/CITYDB_PKG/DELETE/DELETE.sql
@@ -144,7 +144,7 @@ DECLARE
   appearance_ids bigint[] := '{}';
   address_ids bigint[] := '{}';
 BEGIN
-  WITH child_refs AS (
+  WITH property_ids AS (
     DELETE FROM
       property p
     USING
@@ -175,7 +175,7 @@ BEGIN
     appearance_ids,
     address_ids
   FROM
-    child_refs
+    property_ids
   WHERE
     val_feature_id IS NULL OR val_reference_type IS NULL OR val_reference_type = 1;
 


### PR DESCRIPTION
After applying commit a1384f43ee6619fcdbeaa799ef8be290ef105182, the `delete_property` function only deletes the rows for the provided array of IDs but not child rows that are linked via the `parent_id` anymore.

This PR proposes a fix.

1. The current  `delete_property` function is renamed to `delete_property_row`. The function is very useful if the array of provided IDs already contains the child IDs (e.g. when called from `delete_feature`).
2. A new implementation for the `delete_property` function is proposed. In a first step, all child rows are selected using a hierarchical query on `parent_id` for the provided array of IDs. Second, the provided IDs and all selected child IDs are passed to `delete_property_row`.

So, the `delete_property` as proposed in 2) behaves like before commit a1384f43ee6619fcdbeaa799ef8be290ef105182 again.

In the end, the `delete_property_row` is just an internal helper function that should typically not be called by end users. Since we cannot define private functions in PostgreSQL, maybe there is a better name? For example, `intern_delete_property_row` or `_delete_property_row`?