### PR TITLE
Docker v5 beta image releases

### DIFF
--- a/.github/workflows/psql-docker-build-push-release-v5.yml
+++ b/.github/workflows/psql-docker-build-push-release-v5.yml
@@ -86,9 +86,3 @@ jobs:
     -
       name: Image digest
       run: echo ${{ steps.docker_build.outputs.digest }}
-    -
-      name: Inspect image Dockerhub
-      run: docker inspect ${{ env.OWNER_LC }}/${{ env.IMAGE_NAME }}:edge${{ matrix.variant }}
-    -
-      name: Inspect image ghcr.io
-      run: docker inspect ghcr.io/${{ env.OWNER_LC }}/${{ env.IMAGE_NAME }}:edge${{ matrix.variant }}

--- a/.github/workflows/psql-docker-build-push-release-v5.yml
+++ b/.github/workflows/psql-docker-build-push-release-v5.yml
@@ -87,3 +87,9 @@ jobs:
     -
       name: Image digest
       run: echo ${{ steps.docker_build.outputs.digest }}
+    -
+      name: Inspect image
+      run: docker inspect ${{ env.OWNER_LC }}/${{ env.IMAGE_NAME }}:${{ steps.release_version.outputs.version-without-v }}${{ matrix.variant }}
+    -
+      name: Inspect image ghcr.io
+      run: docker inspect ghcr.io/${{ env.OWNER_LC }}/${{ env.IMAGE_NAME }}:${{ steps.release_version.outputs.version-without-v }}${{ matrix.variant }}

--- a/.github/workflows/psql-docker-build-push-release-v5.yml
+++ b/.github/workflows/psql-docker-build-push-release-v5.yml
@@ -19,7 +19,7 @@ jobs:
         variant: ['', '-alpine']    # image variants: '' = debian
 
     # This should only run for releases frm the v5-devel branch
-    if: github.ref == 'refs/heads/v5-devel'
+    if: github.event.release.target_commitish == 'v5-devel'
     steps:
     -
       name: Get release version without v

--- a/.github/workflows/psql-docker-build-push-release-v5.yml
+++ b/.github/workflows/psql-docker-build-push-release-v5.yml
@@ -59,8 +59,8 @@ jobs:
         flavor: |
           latest=${{ !github.event.release.prerelease }}
         tags: |
-          type=semver,pattern={{version}}
-          type=raw,value=latest-beta
+          type=semver,pattern={{version}},suffix=${{ matrix.variant }}
+          type=raw,value=latest-beta,suffix=${{ matrix.variant }}
         labels: |
           maintainer=Bruno Willenborg
           maintainer.email=b.willenborg(at)tum.de

--- a/.github/workflows/psql-docker-build-push-release-v5.yml
+++ b/.github/workflows/psql-docker-build-push-release-v5.yml
@@ -1,0 +1,94 @@
+name: psql-docker-build-push-release-v5
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published, edited]
+
+env:
+  IMAGE_NAME: 3dcitydb-pg-v5
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        baseimage-tag: ['16-3.4']   # base image tags for 'edge' image
+        variant: ['', '-alpine']    # image variants: '' = debian
+
+    # This should only run for releases frm the v5-devel branch
+    if: github.ref == 'refs/heads/v5-devel'
+    steps:
+    -
+      name: Get release version without v
+      id: release_version
+      uses: battila7/get-version-action@v2
+    -
+      name: set lower case owner name
+      run: |
+        echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}
+      env:
+        OWNER: '${{ github.repository_owner }}'
+    -
+      name: Checkout repo
+      uses: actions/checkout@v4
+    -
+      name: Docker login Dockerhub
+      id: docker_login
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+    -
+      name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    -
+      name: Extract metadata (tags, labels) for docker image
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: |
+          ${{ env.OWNER_LC }}/${{ env.IMAGE_NAME }}
+          ghcr.io/${{ env.OWNER_LC }}/${{ env.IMAGE_NAME }}
+        flavor: |
+          latest=${{ !github.event.release.prerelease }}
+        tags: |
+          type=semver,pattern={{version}}
+        labels: |
+          maintainer=Bruno Willenborg
+          maintainer.email=b.willenborg(at)tum.de
+          maintainer.organization=Chair of Geoinformatics, Technical University of Munich (TUM)
+          org.opencontainers.image.authors=Bruno Willenborg
+          org.opencontainers.image.vendor=3DCityDB Steering Committee
+          org.opencontainers.image.title=3D City Database PostgreSQL/PostGIS Docker image
+          org.opencontainers.image.description=Docker image for the 3D City Database based on PostgreSQL and PostGIS
+          org.opencontainers.image.url=https://github.com/3dcitydb/
+          org.opencontainers.image.documentation=https://3dcitydb-docs.readthedocs.io/en/latest/3dcitydb/docker.html
+          org.opencontainers.image.source=https://github.com/3dcitydb/3dcitydb
+    -
+      name: Build and push image
+      id: docker_build
+      uses: docker/build-push-action@v5
+      with:
+        context: ./postgresql
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        build-args: |
+          BASEIMAGE_TAG=${{ matrix.baseimage-tag }}${{ matrix.variant }}
+          CITYDB_VERSION=${{ steps.release_version.outputs.version }}
+    -
+      name: Image digest
+      run: echo ${{ steps.docker_build.outputs.digest }}
+    -
+      name: Inspect image Dockerhub
+      run: docker inspect ${{ env.OWNER_LC }}/${{ env.IMAGE_NAME }}:edge${{ matrix.variant }}
+    -
+      name: Inspect image ghcr.io
+      run: docker inspect ghcr.io/${{ env.OWNER_LC }}/${{ env.IMAGE_NAME }}:edge${{ matrix.variant }}

--- a/.github/workflows/psql-docker-build-push-release-v5.yml
+++ b/.github/workflows/psql-docker-build-push-release-v5.yml
@@ -60,6 +60,7 @@ jobs:
           latest=${{ !github.event.release.prerelease }}
         tags: |
           type=semver,pattern={{version}}
+          type=raw,value=latest-beta
         labels: |
           maintainer=Bruno Willenborg
           maintainer.email=b.willenborg(at)tum.de

--- a/.github/workflows/psql-docker-build-push-release-v5.yml
+++ b/.github/workflows/psql-docker-build-push-release-v5.yml
@@ -66,11 +66,11 @@ jobs:
           maintainer.organization=Chair of Geoinformatics, Technical University of Munich (TUM)
           org.opencontainers.image.authors=Bruno Willenborg
           org.opencontainers.image.vendor=3DCityDB Steering Committee
-          org.opencontainers.image.title=3D City Database PostgreSQL/PostGIS Docker image
-          org.opencontainers.image.description=Docker image for the 3D City Database based on PostgreSQL and PostGIS
+          org.opencontainers.image.title=3D City Database v5 PostgreSQL/PostGIS Docker image
+          org.opencontainers.image.description=Docker image for the 3D City Database v5 based on PostgreSQL and PostGIS
           org.opencontainers.image.url=https://github.com/3dcitydb/
           org.opencontainers.image.documentation=https://3dcitydb-docs.readthedocs.io/en/latest/3dcitydb/docker.html
-          org.opencontainers.image.source=https://github.com/3dcitydb/3dcitydb
+          org.opencontainers.image.source=https://github.com/3dcitydb/3dcitydb/tree/v5-devel
     -
       name: Build and push image
       id: docker_build


### PR DESCRIPTION
### Todos
- [x] Create workflow
- [ ] Add brief documentation of the v5 images to `README.md`

### Description
This PR adds a workflow to create Docker images for pre-releases of v5. This allows us to e.g. pin the compatibility of `citydb-tool` to a specific version.

The workflow will only run for releases targeting the `v5-devel` branch. A **valid SemVer** is required for this to work. Some valid options are:
- `v5.0.0-beta.1`, `v5.0.0-beta.2`, `v5.0.0-beta.3`, ...
- `5.0.0-beta.1`, `5.0.0-beta.2`, `5.0.0-beta.3`, ...
- `5.0.0-beta1`, `5.0.0-beta2`, `5.0.0-beta3`, ...

> **Note:** The leading `v` in version numbers is always stripped from the Docker image tag:
> Git tag/release version = `v5.0.0-beta.1` -> Image tag = `5.0.0-beta.1`

**We should agree to one versioning pattern and stick to it.**

For convenience, an additional `latest-beta` image is created for the latest beta-release:
- `v5.0.0-beta.1`, `v5.0.0-beta.2`, `v5.0.0-beta.3` -> `latest-beta`

There is an `alpine` version too. For each image the `-alpine` variant exists:

- `v5.0.0-beta.1-alpine`, `v5.0.0-beta.2-alpine`, `v5.0.0-beta.3-alpine`, ...
- `latest-beta-alpine`

### Testing
Some test releases and the resulting images are im my fork: 
- Releases: https://github.com/BWibo/3dcitydb/releases
- Images: https://github.com/BWibo/3dcitydb/pkgs/container/3dcitydb-pg-v5

### Example

This shows how a beta release could look like in the Github UI.
![grafik](https://github.com/3dcitydb/3dcitydb/assets/7643434/b74e0977-eb7f-49bc-81b6-574851120f41)

