### PR TITLE
Shell scripts can now be called outside their folder

### DIFF
--- a/postgresql/shell-scripts/unix/create-db.sh
+++ b/postgresql/shell-scripts/unix/create-db.sh
@@ -2,14 +2,20 @@
 # Shell script to create an instance of the 3D City Database
 # on PostgreSQL/PostGIS
 
-# read database connection details 
-source connection-details.sh
-
-# add PGBIN to PATH
+# Add PGBIN to PATH
 export PATH="$PGBIN:$PATH"
 
-# cd to path of the shell script
-cd "$( cd "$( dirname "$0" )" && pwd )" > /dev/null
+# Get the current directory path of this script file
+CURRENT_DIR="$( cd "$( dirname "$0" )" && pwd )"
+if [ $# -ne 0 ]; then
+  source "$1"
+else
+  if [ -f connection-details.sh ]; then
+	  source connection-details.sh
+  else
+	  source "$CURRENT_DIR/connection-details.sh"
+  fi
+fi
 
 # Welcome message
 echo ' _______   ___ _ _        ___  ___ '
@@ -36,9 +42,6 @@ echo '   Please file an issue here:'
 echo '   https://github.com/3dcitydb/3dcitydb/issues'
 echo
 echo '######################################################################################'
-
-# cd to path of the SQL scripts
-cd ../../sql-scripts
 
 # Prompt for SRID -------------------------------------------------------------
 re='^[0-9]+$'
@@ -86,7 +89,7 @@ SRS_NAME=${var:-$SRS_NAME}
 # Run create-db.sql to create the 3D City Database instance -------------------
 echo
 echo "Connecting to \"$PGUSER@$PGHOST:$PGPORT/$CITYDB\" ..."
-psql -d "$CITYDB" -f "create-db.sql" -v srid="$SRID" -v srs_name="$SRS_NAME"
+psql -d "$CITYDB" -f "$CURRENT_DIR/../../sql-scripts/create-db.sql" -v srid="$SRID" -v srs_name="$SRS_NAME"
 
 echo
 read -rsn1 -p 'Press ENTER to quit.'

--- a/postgresql/shell-scripts/unix/create-db.sh
+++ b/postgresql/shell-scripts/unix/create-db.sh
@@ -2,9 +2,6 @@
 # Shell script to create an instance of the 3D City Database
 # on PostgreSQL/PostGIS
 
-# Add PGBIN to PATH
-export PATH="$PGBIN:$PATH"
-
 # Get the current directory path of this script file
 CURRENT_DIR="$( cd "$( dirname "$0" )" && pwd )"
 if [ $# -ne 0 ]; then
@@ -16,6 +13,9 @@ else
 	  source "$CURRENT_DIR/connection-details.sh"
   fi
 fi
+
+# Add PGBIN to PATH
+export PATH="$PGBIN:$PATH"
 
 # Welcome message
 echo ' _______   ___ _ _        ___  ___ '

--- a/postgresql/shell-scripts/unix/create-schema.sh
+++ b/postgresql/shell-scripts/unix/create-schema.sh
@@ -2,9 +2,6 @@
 # Shell script to create an new new 3DCityDB schema
 # on PostgreSQL/PostGIS
 
-# Add PGBIN to PATH
-export PATH="$PGBIN:$PATH"
-
 # Get the current directory path of this script file
 CURRENT_DIR="$( cd "$( dirname "$0" )" && pwd )"
 if [ $# -ne 0 ]; then
@@ -16,6 +13,9 @@ else
 	  source "$CURRENT_DIR/connection-details.sh"
   fi
 fi
+
+# Add PGBIN to PATH
+export PATH="$PGBIN:$PATH"
 
 # Welcome message
 echo ' _______   ___ _ _        ___  ___ '

--- a/postgresql/shell-scripts/unix/create-schema.sh
+++ b/postgresql/shell-scripts/unix/create-schema.sh
@@ -2,14 +2,20 @@
 # Shell script to create an new new 3DCityDB schema
 # on PostgreSQL/PostGIS
 
-# read database connection details
-source connection-details.sh
-
-# add PGBIN to PATH
+# Add PGBIN to PATH
 export PATH="$PGBIN:$PATH"
 
-# cd to path of the shell script
-cd "$( cd "$( dirname "$0" )" && pwd )" > /dev/null
+# Get the current directory path of this script file
+CURRENT_DIR="$( cd "$( dirname "$0" )" && pwd )"
+if [ $# -ne 0 ]; then
+  source "$1"
+else
+  if [ -f connection-details.sh ]; then
+	  source connection-details.sh
+  else
+	  source "$CURRENT_DIR/connection-details.sh"
+  fi
+fi
 
 # Welcome message
 echo ' _______   ___ _ _        ___  ___ '
@@ -37,13 +43,10 @@ echo '   https://github.com/3dcitydb/3dcitydb/issues'
 echo
 echo '#####################################################################################'
 
-# cd to path of the SQL scripts
-cd ../../sql-scripts
-
 # List the existing 3DCityDB schemas ------------------------------------------
 echo
 echo "Reading 3DCityDB schemas from \"$PGUSER@$PGHOST:$PGPORT/$CITYDB\" ..."
-psql -d "$CITYDB" -f "util/list-schemas.sql"
+psql -d "$CITYDB" -f "$CURRENT_DIR/../../sql-scripts/util/list-schemas.sql"
 
 if [[ $? -ne 0 ]] ; then
   echo 'Failed to read 3DCityDB schemas from database.'
@@ -61,7 +64,7 @@ SCHEMA_NAME=${var:-$SCHEMA_NAME}
 # Run create-schema.sql to create a new 3DCityDB schema -----------------------
 echo
 echo "Connecting to \"$PGUSER@$PGHOST:$PGPORT/$CITYDB\" ..."
-psql -d "$CITYDB" -f "create-schema.sql" -v schema_name="$SCHEMA_NAME"
+psql -d "$CITYDB" -f "$CURRENT_DIR/../../sql-scripts/create-schema.sql" -v schema_name="$SCHEMA_NAME"
 
 echo
 read -rsn1 -p 'Press ENTER to quit.'

--- a/postgresql/shell-scripts/unix/drop-db.sh
+++ b/postgresql/shell-scripts/unix/drop-db.sh
@@ -2,9 +2,6 @@
 # Shell script to drop an instance of the 3D City Database
 # on PostgreSQL/PostGIS
 
-# Add PGBIN to PATH
-export PATH="$PGBIN:$PATH"
-
 # Get the current directory path of this script file
 CURRENT_DIR="$( cd "$( dirname "$0" )" && pwd )"
 if [ $# -ne 0 ]; then
@@ -16,6 +13,9 @@ else
 	  source "$CURRENT_DIR/connection-details.sh"
   fi
 fi
+
+# Add PGBIN to PATH
+export PATH="$PGBIN:$PATH"
 
 # Welcome message
 echo ' _______   ___ _ _        ___  ___ '

--- a/postgresql/shell-scripts/unix/drop-db.sh
+++ b/postgresql/shell-scripts/unix/drop-db.sh
@@ -2,14 +2,20 @@
 # Shell script to drop an instance of the 3D City Database
 # on PostgreSQL/PostGIS
 
-# read database connection details 
-source connection-details.sh
-
-# add PGBIN to PATH
+# Add PGBIN to PATH
 export PATH="$PGBIN:$PATH"
 
-# cd to path of the shell script
-cd "$( cd "$( dirname "$0" )" && pwd )" > /dev/null
+# Get the current directory path of this script file
+CURRENT_DIR="$( cd "$( dirname "$0" )" && pwd )"
+if [ $# -ne 0 ]; then
+  source "$1"
+else
+  if [ -f connection-details.sh ]; then
+	  source connection-details.sh
+  else
+	  source "$CURRENT_DIR/connection-details.sh"
+  fi
+fi
 
 # Welcome message
 echo ' _______   ___ _ _        ___  ___ '
@@ -35,13 +41,10 @@ echo '   https://github.com/3dcitydb/3dcitydb/issues'
 echo
 echo '################################################################################'
 
-# cd to path of the SQL scripts
-cd ../../sql-scripts
-
 # Run drop-db.sql to drop the 3D City Database instance -----------------------
 echo
 echo "Connecting to \"$PGUSER@$PGHOST:$PGPORT/$CITYDB\" ..."
-psql -d "$CITYDB" -f "drop-db.sql"
+psql -d "$CITYDB" -f "$CURRENT_DIR/../../sql-scripts/drop-db.sql"
 
 echo
 read -rsn1 -p 'Press ENTER to quit.'

--- a/postgresql/shell-scripts/unix/drop-schema.sh
+++ b/postgresql/shell-scripts/unix/drop-schema.sh
@@ -2,14 +2,20 @@
 # Shell script to drop a schema from a 3DCityDB instance
 # on PostgreSQL/PostGIS
 
-# read database connection details 
-source connection-details.sh
-
-# add PGBIN to PATH
+# Add PGBIN to PATH
 export PATH="$PGBIN:$PATH"
 
-# cd to path of the shell script
-cd "$( cd "$( dirname "$0" )" && pwd )" > /dev/null
+# Get the current directory path of this script file
+CURRENT_DIR="$( cd "$( dirname "$0" )" && pwd )"
+if [ $# -ne 0 ]; then
+  source "$1"
+else
+  if [ -f connection-details.sh ]; then
+	  source connection-details.sh
+  else
+	  source "$CURRENT_DIR/connection-details.sh"
+  fi
+fi
 
 # Welcome message
 echo ' _______   ___ _ _        ___  ___ '
@@ -37,13 +43,10 @@ echo '   https://github.com/3dcitydb/3dcitydb/issues'
 echo
 echo '############################################################################'
 
-# cd to path of the SQL scripts
-cd ../../sql-scripts
-
 # List the existing 3DCityDB schemas ------------------------------------------
 echo
 echo "Reading 3DCityDB schemas from \"$PGUSER@$PGHOST:$PGPORT/$CITYDB\" ..."
-psql -d "$CITYDB" -f "util/list-schemas.sql"
+psql -d "$CITYDB" -f "$CURRENT_DIR/../../sql-scripts/util/list-schemas.sql"
 
 if [[ $? -ne 0 ]] ; then
   echo 'Failed to read 3DCityDB schemas from database.'
@@ -69,7 +72,7 @@ done;
 # Run drop-schema.sql to remove the selected 3DCityDB schema ------------------
 echo
 echo "Connecting to \"$PGUSER@$PGHOST:$PGPORT/$CITYDB\" ..."
-psql -d "$CITYDB" -f "drop-schema.sql" -v schema_name="$SCHEMA_NAME"
+psql -d "$CITYDB" -f "$CURRENT_DIR/../../sql-scripts/drop-schema.sql" -v schema_name="$SCHEMA_NAME"
 
 echo
 read -rsn1 -p 'Press ENTER to quit.'

--- a/postgresql/shell-scripts/unix/drop-schema.sh
+++ b/postgresql/shell-scripts/unix/drop-schema.sh
@@ -2,9 +2,6 @@
 # Shell script to drop a schema from a 3DCityDB instance
 # on PostgreSQL/PostGIS
 
-# Add PGBIN to PATH
-export PATH="$PGBIN:$PATH"
-
 # Get the current directory path of this script file
 CURRENT_DIR="$( cd "$( dirname "$0" )" && pwd )"
 if [ $# -ne 0 ]; then
@@ -16,6 +13,9 @@ else
 	  source "$CURRENT_DIR/connection-details.sh"
   fi
 fi
+
+# Add PGBIN to PATH
+export PATH="$PGBIN:$PATH"
 
 # Welcome message
 echo ' _______   ___ _ _        ___  ___ '

--- a/postgresql/shell-scripts/unix/grant-access.sh
+++ b/postgresql/shell-scripts/unix/grant-access.sh
@@ -2,14 +2,20 @@
 # Shell script to grant access privileges to a 3DCityDB schema
 # on PostgreSQL/PostGIS
 
-# read database connection details
-source connection-details.sh
-
-# add PGBIN to PATH
+# Add PGBIN to PATH
 export PATH="$PGBIN:$PATH"
 
-# cd to path of the shell script
-cd "$( cd "$( dirname "$0" )" && pwd )" > /dev/null
+# Get the current directory path of this script file
+CURRENT_DIR="$( cd "$( dirname "$0" )" && pwd )"
+if [ $# -ne 0 ]; then
+  source "$1"
+else
+  if [ -f connection-details.sh ]; then
+	  source connection-details.sh
+  else
+	  source "$CURRENT_DIR/connection-details.sh"
+  fi
+fi
 
 # Welcome message
 echo ' _______   ___ _ _        ___  ___ '
@@ -39,9 +45,6 @@ echo '   https://github.com/3dcitydb/3dcitydb/issues'
 echo
 echo '####################################################################################'
 
-# cd to path of the SQL scripts
-cd ../../sql-scripts
-
 # Prompt for GRANTEE ----------------------------------------------------------
 while [ 1 ]; do
   echo
@@ -59,7 +62,7 @@ done
 # List the existing 3DCityDB schemas ------------------------------------------
 echo
 echo "Reading 3DCityDB schemas from \"$PGUSER@$PGHOST:$PGPORT/$CITYDB\" ..."
-psql -d "$CITYDB" -f "util/list-schemas.sql"
+psql -d "$CITYDB" -f "$CURRENT_DIR/../../sql-scripts/util/list-schemas.sql"
 
 if [[ $? -ne 0 ]] ; then
   echo 'Failed to read 3DCityDB schemas from database.'
@@ -95,7 +98,7 @@ done
 # Run grant-access.sql to grant access privileges on a specific schema --------
 echo
 echo "Connecting to \"$PGUSER@$PGHOST:$PGPORT/$CITYDB\" ..."
-psql -d "$CITYDB" -f "grant-access.sql" -v username="$GRANTEE" -v schema_name="$SCHEMA_NAME" -v access_mode="$ACCESS_MODE"
+psql -d "$CITYDB" -f "$CURRENT_DIR/../../sql-scripts/grant-access.sql" -v username="$GRANTEE" -v schema_name="$SCHEMA_NAME" -v access_mode="$ACCESS_MODE"
 
 echo
 read -rsn1 -p 'Press ENTER to quit.'

--- a/postgresql/shell-scripts/unix/grant-access.sh
+++ b/postgresql/shell-scripts/unix/grant-access.sh
@@ -2,9 +2,6 @@
 # Shell script to grant access privileges to a 3DCityDB schema
 # on PostgreSQL/PostGIS
 
-# Add PGBIN to PATH
-export PATH="$PGBIN:$PATH"
-
 # Get the current directory path of this script file
 CURRENT_DIR="$( cd "$( dirname "$0" )" && pwd )"
 if [ $# -ne 0 ]; then
@@ -16,6 +13,9 @@ else
 	  source "$CURRENT_DIR/connection-details.sh"
   fi
 fi
+
+# Add PGBIN to PATH
+export PATH="$PGBIN:$PATH"
 
 # Welcome message
 echo ' _______   ___ _ _        ___  ___ '

--- a/postgresql/shell-scripts/unix/revoke-access.sh
+++ b/postgresql/shell-scripts/unix/revoke-access.sh
@@ -2,9 +2,6 @@
 # Shell script to revoke access privileges from a 3DCityDB schema
 # on PostgreSQL/PostGIS
 
-# Add PGBIN to PATH
-export PATH="$PGBIN:$PATH"
-
 # Get the current directory path of this script file
 CURRENT_DIR="$( cd "$( dirname "$0" )" && pwd )"
 if [ $# -ne 0 ]; then
@@ -16,6 +13,9 @@ else
 	  source "$CURRENT_DIR/connection-details.sh"
   fi
 fi
+
+# Add PGBIN to PATH
+export PATH="$PGBIN:$PATH"
 
 # Welcome message
 echo ' _______   ___ _ _        ___  ___ '

--- a/postgresql/shell-scripts/unix/revoke-access.sh
+++ b/postgresql/shell-scripts/unix/revoke-access.sh
@@ -2,14 +2,20 @@
 # Shell script to revoke access privileges from a 3DCityDB schema
 # on PostgreSQL/PostGIS
 
-# read database connection details
-source connection-details.sh
-
-# add PGBIN to PATH
+# Add PGBIN to PATH
 export PATH="$PGBIN:$PATH"
 
-# cd to path of the shell script
-cd "$( cd "$( dirname "$0" )" && pwd )" > /dev/null
+# Get the current directory path of this script file
+CURRENT_DIR="$( cd "$( dirname "$0" )" && pwd )"
+if [ $# -ne 0 ]; then
+  source "$1"
+else
+  if [ -f connection-details.sh ]; then
+	  source connection-details.sh
+  else
+	  source "$CURRENT_DIR/connection-details.sh"
+  fi
+fi
 
 # Welcome message
 echo ' _______   ___ _ _        ___  ___ '
@@ -39,9 +45,6 @@ echo '   https://github.com/3dcitydb/3dcitydb/issues'
 echo
 echo '#######################################################################################'
 
-# cd to path of the SQL scripts
-cd ../../sql-scripts
-
 # Prompt for GRANTEE ----------------------------------------------------------
 while [ 1 ]; do
   echo
@@ -59,7 +62,7 @@ done
 # List the 3DCityDB schemas granted to GRANTEE --------------------------------
 echo
 echo "Reading 3DCityDB schemas granted to \"$GRANTEE\" from \"$PGUSER@$PGHOST:$PGPORT/$CITYDB\" ..."
-psql -d "$CITYDB" -f "util/list-schemas-with-access-grant.sql" -v username="$GRANTEE"
+psql -d "$CITYDB" -f "$CURRENT_DIR/../../sql-scripts/util/list-schemas-with-access-grant.sql" -v username="$GRANTEE"
 
 if [[ $? -ne 0 ]] ; then
   echo 'Failed to read 3DCityDB schemas from database.'
@@ -77,7 +80,7 @@ SCHEMA_NAME=${var:-$SCHEMA_NAME}
 # Run revoke-access.sql to revoke read-only access on a specific schema -------
 echo
 echo "Connecting to \"$PGUSER@$PGHOST:$PGPORT/$CITYDB\" ..."
-psql -d "$CITYDB" -f "revoke-access.sql" -v username="$GRANTEE" -v schema_name="$SCHEMA_NAME"
+psql -d "$CITYDB" -f "$CURRENT_DIR/../../sql-scripts/revoke-access.sql" -v username="$GRANTEE" -v schema_name="$SCHEMA_NAME"
 
 echo
 read -rsn1 -p 'Press ENTER to quit.'

--- a/postgresql/shell-scripts/windows/create-db.bat
+++ b/postgresql/shell-scripts/windows/create-db.bat
@@ -2,14 +2,22 @@
 :: Shell script to create an instance of the 3D City Database
 :: on PostgreSQL/PostGIS
 
-:: read database connection details  
-call connection-details.bat
-
-:: add PGBIN to PATH
+:: Add PGBIN to PATH
 set PATH=%PGBIN%;%PATH%;%SYSTEMROOT%\System32
 
-:: cd to path of the shell script
-cd /d %~dp0
+:: Get the current directory path of this script file
+set CURRENT_DIR=%~dp0
+
+:: Read database connection details
+if NOT [%1]==[] (
+  call %1
+) else (
+  if exist connection-details.bat (
+    call connection-details.bat
+  ) else (
+    call "%CURRENT_DIR%connection-details.bat"
+  )
+)
 
 :: Welcome message
 echo  _______   ___ _ _        ___  ___
@@ -36,9 +44,6 @@ echo    Please file an issue here:
 echo    https://github.com/3dcitydb/3dcitydb/issues
 echo.
 echo ######################################################################################
-
-:: cd to path of the SQL scripts
-cd ..\..\sql-scripts
 
 :: Prompt for SRID ------------------------------------------------------------
 :srid
@@ -103,6 +108,6 @@ if /i not "%var%"=="" set SRS_NAME=%var%
 :: Run create-db.sql to create the 3D City Database instance ------------------
 echo.
 echo Connecting to "%PGUSER%@%PGHOST%:%PGPORT%/%CITYDB%" ...
-psql -d "%CITYDB%" -f "create-db.sql" -v srid="%SRID%" -v srs_name="%SRS_NAME%"
+psql -d "%CITYDB%" -f "%CURRENT_DIR%..\..\sql-scripts\create-db.sql" -v srid="%SRID%" -v srs_name="%SRS_NAME%"
 
 pause

--- a/postgresql/shell-scripts/windows/create-db.bat
+++ b/postgresql/shell-scripts/windows/create-db.bat
@@ -2,9 +2,6 @@
 :: Shell script to create an instance of the 3D City Database
 :: on PostgreSQL/PostGIS
 
-:: Add PGBIN to PATH
-set PATH=%PGBIN%;%PATH%;%SYSTEMROOT%\System32
-
 :: Get the current directory path of this script file
 set CURRENT_DIR=%~dp0
 
@@ -18,6 +15,9 @@ if NOT [%1]==[] (
     call "%CURRENT_DIR%connection-details.bat"
   )
 )
+
+:: Add PGBIN to PATH
+set PATH=%PGBIN%;%PATH%;%SYSTEMROOT%\System32
 
 :: Welcome message
 echo  _______   ___ _ _        ___  ___

--- a/postgresql/shell-scripts/windows/create-schema.bat
+++ b/postgresql/shell-scripts/windows/create-schema.bat
@@ -2,14 +2,22 @@
 :: Shell script to create an new 3DCityDB schema
 :: on PostgreSQL/PostGIS
 
-:: read database connection details  
-call connection-details.bat
-
 :: add PGBIN to PATH
 set PATH=%PGBIN%;%PATH%;%SYSTEMROOT%\System32
 
-:: cd to path of the shell script
-cd /d %~dp0
+:: Get the current directory path of this script file
+set CURRENT_DIR=%~dp0
+
+:: Read database connection details
+if NOT [%1]==[] (
+  call %1
+) else (
+  if exist connection-details.bat (
+    call connection-details.bat
+  ) else (
+    call "%CURRENT_DIR%connection-details.bat"
+  )
+)
 
 :: Welcome message
 echo  _______   ___ _ _        ___  ___
@@ -37,13 +45,10 @@ echo    https://github.com/3dcitydb/3dcitydb/issues
 echo.
 echo #####################################################################################
 
-:: cd to path of the SQL scripts
-cd ..\..\sql-scripts
-
 :: List the existing 3DCityDB schemas -----------------------------------------
 echo.
 echo Reading 3DCityDB schemas from "%PGUSER%@%PGHOST%:%PGPORT%/%CITYDB%" ...
-psql -d "%CITYDB%" -f "util\list-schemas.sql"
+psql -d "%CITYDB%" -f "%CURRENT_DIR%..\..\sql-scripts\util\list-schemas.sql"
 
 if errorlevel 1 (
   echo Failed to read 3DCityDB schemas from database.
@@ -60,6 +65,6 @@ if /i not "%var%"=="" set SCHEMA_NAME=%var%
 :: Run create-schema.sql to create a new 3DCityDB schema ----------------------
 echo.
 echo Connecting to "%PGUSER%@%PGHOST%:%PGPORT%/%CITYDB%" ...
-psql -d "%CITYDB%" -f "create-schema.sql" -v schema_name="%SCHEMA_NAME%"
+psql -d "%CITYDB%" -f "%CURRENT_DIR%..\..\sql-scripts\create-schema.sql" -v schema_name="%SCHEMA_NAME%"
 
 pause

--- a/postgresql/shell-scripts/windows/create-schema.bat
+++ b/postgresql/shell-scripts/windows/create-schema.bat
@@ -2,9 +2,6 @@
 :: Shell script to create an new 3DCityDB schema
 :: on PostgreSQL/PostGIS
 
-:: add PGBIN to PATH
-set PATH=%PGBIN%;%PATH%;%SYSTEMROOT%\System32
-
 :: Get the current directory path of this script file
 set CURRENT_DIR=%~dp0
 
@@ -18,6 +15,9 @@ if NOT [%1]==[] (
     call "%CURRENT_DIR%connection-details.bat"
   )
 )
+
+:: Add PGBIN to PATH
+set PATH=%PGBIN%;%PATH%;%SYSTEMROOT%\System32
 
 :: Welcome message
 echo  _______   ___ _ _        ___  ___

--- a/postgresql/shell-scripts/windows/drop-db.bat
+++ b/postgresql/shell-scripts/windows/drop-db.bat
@@ -2,9 +2,6 @@
 :: Shell script to drop an instance of the 3D City Database
 :: on PostgreSQL/PostGIS
 
-:: add PGBIN to PATH
-set PATH=%PGBIN%;%PATH%;%SYSTEMROOT%\System32
-
 :: Get the current directory path of this script file
 set CURRENT_DIR=%~dp0
 
@@ -18,6 +15,9 @@ if NOT [%1]==[] (
     call "%CURRENT_DIR%connection-details.bat"
   )
 )
+
+:: Add PGBIN to PATH
+set PATH=%PGBIN%;%PATH%;%SYSTEMROOT%\System32
 
 :: Welcome message
 echo  _______   ___ _ _        ___  ___

--- a/postgresql/shell-scripts/windows/drop-db.bat
+++ b/postgresql/shell-scripts/windows/drop-db.bat
@@ -2,14 +2,22 @@
 :: Shell script to drop an instance of the 3D City Database
 :: on PostgreSQL/PostGIS
 
-:: read database connection details  
-call connection-details.bat
-
 :: add PGBIN to PATH
 set PATH=%PGBIN%;%PATH%;%SYSTEMROOT%\System32
 
-:: cd to path of the shell script
-cd /d %~dp0
+:: Get the current directory path of this script file
+set CURRENT_DIR=%~dp0
+
+:: Read database connection details
+if NOT [%1]==[] (
+  call %1
+) else (
+  if exist connection-details.bat (
+    call connection-details.bat
+  ) else (
+    call "%CURRENT_DIR%connection-details.bat"
+  )
+)
 
 :: Welcome message
 echo  _______   ___ _ _        ___  ___
@@ -35,12 +43,9 @@ echo    https://github.com/3dcitydb/3dcitydb/issues
 echo.
 echo ################################################################################
 
-:: cd to path of the SQL scripts
-cd ..\..\sql-scripts
-
 REM Run drop-db.sql to drop the 3D City Database instance ---------------------
 echo.
 echo Connecting to "%PGUSER%@%PGHOST%:%PGPORT%/%CITYDB%" ...
-psql -d "%CITYDB%" -f "drop-db.sql"
+psql -d "%CITYDB%" -f "%CURRENT_DIR%..\..\sql-scripts\drop-db.sql"
 
 pause

--- a/postgresql/shell-scripts/windows/drop-schema.bat
+++ b/postgresql/shell-scripts/windows/drop-schema.bat
@@ -2,9 +2,6 @@
 :: Shell script to drop a schema from a 3DCityDB instance
 :: on PostgreSQL/PostGIS
 
-:: add PGBIN to PATH
-set PATH=%PGBIN%;%PATH%;%SYSTEMROOT%\System32
-
 :: Get the current directory path of this script file
 set CURRENT_DIR=%~dp0
 
@@ -18,6 +15,9 @@ if NOT [%1]==[] (
     call "%CURRENT_DIR%connection-details.bat"
   )
 )
+
+:: Add PGBIN to PATH
+set PATH=%PGBIN%;%PATH%;%SYSTEMROOT%\System32
 
 :: Welcome message
 echo  _______   ___ _ _        ___  ___

--- a/postgresql/shell-scripts/windows/drop-schema.bat
+++ b/postgresql/shell-scripts/windows/drop-schema.bat
@@ -2,14 +2,22 @@
 :: Shell script to drop a schema from a 3DCityDB instance
 :: on PostgreSQL/PostGIS
 
-:: read database connection details  
-call connection-details.bat
-
 :: add PGBIN to PATH
 set PATH=%PGBIN%;%PATH%;%SYSTEMROOT%\System32
 
-:: cd to path of the shell script
-cd /d %~dp0
+:: Get the current directory path of this script file
+set CURRENT_DIR=%~dp0
+
+:: Read database connection details
+if NOT [%1]==[] (
+  call %1
+) else (
+  if exist connection-details.bat (
+    call connection-details.bat
+  ) else (
+    call "%CURRENT_DIR%connection-details.bat"
+  )
+)
 
 :: Welcome message
 echo  _______   ___ _ _        ___  ___
@@ -37,13 +45,10 @@ echo    https://github.com/3dcitydb/3dcitydb/issues
 echo.
 echo ############################################################################
 
-:: cd to path of the SQL scripts
-cd ..\..\sql-scripts
-
 :: List the existing 3DCityDB schemas -----------------------------------------
 echo.
 echo Reading 3DCityDB schemas "%PGUSER%@%PGHOST%:%PGPORT%/%CITYDB%" ...
-psql -d "%CITYDB%" -f "util\list-schemas.sql"
+psql -d "%CITYDB%" -f "%CURRENT_DIR%..\..\sql-scripts\util\list-schemas.sql"
 
 if errorlevel 1 (
   echo Failed to read schemas from database.
@@ -69,6 +74,6 @@ if /i not "%var%"=="" (
 :: Run drop-schema.sql to remove the selected 3DCityDB schema -----------------
 echo.
 echo Connecting to "%PGUSER%@%PGHOST%:%PGPORT%/%CITYDB%" ...
-psql -d "%CITYDB%" -f "drop-schema.sql" -v schema_name="%SCHEMA_NAME%"
+psql -d "%CITYDB%" -f "%CURRENT_DIR%..\..\sql-scripts\drop-schema.sql" -v schema_name="%SCHEMA_NAME%"
 
 pause

--- a/postgresql/shell-scripts/windows/grant-access.bat
+++ b/postgresql/shell-scripts/windows/grant-access.bat
@@ -2,14 +2,22 @@
 :: Shell script to grant access privileges to a 3DCityDB schema
 :: on PostgreSQL/PostGIS
 
-:: read database connection details  
-call connection-details.bat
-
 :: add PGBIN to PATH
 set PATH=%PGBIN%;%PATH%;%SYSTEMROOT%\System32
 
-:: cd to path of the shell script
-cd /d %~dp0
+:: Get the current directory path of this script file
+set CURRENT_DIR=%~dp0
+
+:: Read database connection details
+if NOT [%1]==[] (
+  call %1
+) else (
+  if exist connection-details.bat (
+    call connection-details.bat
+  ) else (
+    call "%CURRENT_DIR%connection-details.bat"
+  )
+)
 
 :: Welcome message
 echo  _______   ___ _ _        ___  ___
@@ -39,9 +47,6 @@ echo    https://github.com/3dcitydb/3dcitydb/issues
 echo.
 echo ####################################################################################
 
-:: cd to path of the SQL scripts
-cd ..\..\sql-scripts
-
 :: Prompt for GRANTEE ---------------------------------------------------------
 :grantee
 set var=
@@ -60,7 +65,7 @@ if /i not "%var%"=="" (
 :: List the existing 3DCityDB schemas -----------------------------------------
 echo.
 echo Reading 3DCityDB schemas from "%PGUSER%@%PGHOST%:%PGPORT%/%CITYDB%" ...
-psql -d "%CITYDB%" -f "util\list-schemas.sql"
+psql -d "%CITYDB%" -f "%CURRENT_DIR%..\..\sql-scripts\util\list-schemas.sql"
 
 if errorlevel 1 (
   echo Failed to read 3DCityDB schemas from database.
@@ -100,6 +105,6 @@ if "%res%"=="f" (
 :: Run grant-access.sql to grant access privileges on a specific schema -------
 echo.
 echo Connecting to "%PGUSER%@%PGHOST%:%PGPORT%/%CITYDB%" ...
-psql -d "%CITYDB%" -f "grant-access.sql" -v username="%GRANTEE%" -v schema_name="%SCHEMA_NAME%" -v access_mode="%ACCESS_MODE%"
+psql -d "%CITYDB%" -f "%CURRENT_DIR%..\..\sql-scripts\grant-access.sql" -v username="%GRANTEE%" -v schema_name="%SCHEMA_NAME%" -v access_mode="%ACCESS_MODE%"
 
 pause

--- a/postgresql/shell-scripts/windows/grant-access.bat
+++ b/postgresql/shell-scripts/windows/grant-access.bat
@@ -2,9 +2,6 @@
 :: Shell script to grant access privileges to a 3DCityDB schema
 :: on PostgreSQL/PostGIS
 
-:: add PGBIN to PATH
-set PATH=%PGBIN%;%PATH%;%SYSTEMROOT%\System32
-
 :: Get the current directory path of this script file
 set CURRENT_DIR=%~dp0
 
@@ -18,6 +15,9 @@ if NOT [%1]==[] (
     call "%CURRENT_DIR%connection-details.bat"
   )
 )
+
+:: Add PGBIN to PATH
+set PATH=%PGBIN%;%PATH%;%SYSTEMROOT%\System32
 
 :: Welcome message
 echo  _______   ___ _ _        ___  ___

--- a/postgresql/shell-scripts/windows/revoke-access.bat
+++ b/postgresql/shell-scripts/windows/revoke-access.bat
@@ -2,14 +2,22 @@
 :: Shell script to revoke access privileges from a 3DCityDB schema
 :: on PostgreSQL/PostGIS
 
-:: read database connection details  
-call connection-details.bat
-
 :: add PGBIN to PATH
 set PATH=%PGBIN%;%PATH%;%SYSTEMROOT%\System32
 
-:: cd to path of the shell script
-cd /d %~dp0
+:: Get the current directory path of this script file
+set CURRENT_DIR=%~dp0
+
+:: Read database connection details
+if NOT [%1]==[] (
+  call %1
+) else (
+  if exist connection-details.bat (
+    call connection-details.bat
+  ) else (
+    call "%CURRENT_DIR%connection-details.bat"
+  )
+)
 
 :: Welcome message
 echo  _______   ___ _ _        ___  ___
@@ -60,7 +68,7 @@ if /i not "%var%"=="" (
 :: List the 3DCityDB schemas granted to GRANTEE -------------------------------
 echo.
 echo Reading 3DCityDB schemas granted to "%GRANTEE%" from "%PGUSER%@%PGHOST%:%PGPORT%/%CITYDB%" ...
-psql -d "%CITYDB%" -f "util\list-schemas-with-access-grant.sql" -v username="%GRANTEE%"
+psql -d "%CITYDB%" -f "%CURRENT_DIR%..\..\sql-scripts\util\list-schemas-with-access-grant.sql" -v username="%GRANTEE%"
 
 if errorlevel 1 (
   echo Failed to read 3DCityDB schemas from database.
@@ -78,6 +86,6 @@ if /i not "%var%"=="" set SCHEMA_NAME=%var%
 :: Run revoke-access.sql to revoke access privileges on a specific schema -----
 echo.
 echo Connecting to "%PGUSER%@%PGHOST%:%PGPORT%/%CITYDB%" ...
-psql -d "%CITYDB%" -f "revoke-access.sql" -v username="%GRANTEE%" -v schema_name="%SCHEMA_NAME%"
+psql -d "%CITYDB%" -f "%CURRENT_DIR%..\..\sql-scripts\revoke-access.sql" -v username="%GRANTEE%" -v schema_name="%SCHEMA_NAME%"
 
 pause

--- a/postgresql/shell-scripts/windows/revoke-access.bat
+++ b/postgresql/shell-scripts/windows/revoke-access.bat
@@ -2,9 +2,6 @@
 :: Shell script to revoke access privileges from a 3DCityDB schema
 :: on PostgreSQL/PostGIS
 
-:: add PGBIN to PATH
-set PATH=%PGBIN%;%PATH%;%SYSTEMROOT%\System32
-
 :: Get the current directory path of this script file
 set CURRENT_DIR=%~dp0
 
@@ -18,6 +15,9 @@ if NOT [%1]==[] (
     call "%CURRENT_DIR%connection-details.bat"
   )
 )
+
+:: Add PGBIN to PATH
+set PATH=%PGBIN%;%PATH%;%SYSTEMROOT%\System32
 
 :: Welcome message
 echo  _______   ___ _ _        ___  ___


### PR DESCRIPTION
Currently, the shell scripts must be called inside their folder (`unix` or `window`), and the database connection information must be specificed in the `connection-details` file. 

This MR provides an improvement. Users can now call the shell script e.g. `create-db.bat` from anywhere via its absolute or relative  path. In addition, a command argument for specifying the path of a database connection file is available. If the argument is not given, the `connection-details.sh` in the current working folder or in the target shell script folder will be used. 