### PR TITLE
Add ADE hooks meta-info into the datatype table

### DIFF
--- a/postgresql/sql-scripts/schema/datatype-instances.sql
+++ b/postgresql/sql-scripts/schema/datatype-instances.sql
@@ -69,13 +69,13 @@ INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCH
 VALUES (22, null, 'StringOrRef', 0, 1, @core:StringOrRef@);
 
 INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
-VALUES (23, null, 'ADEOfAbstractAppearance', 1, 1, @core:ADEOfAbstractAppearance@);
+VALUES (23, null, 'ADEOfAbstractCityObject', 1, 1, @core:ADEOfAbstractCityObject@);
 
 INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
-VALUES (24, null, 'ADEOfAbstractCityObject', 1, 1, @core:ADEOfAbstractCityObject@);
+VALUES (24, null, 'ADEOfAbstractDynamizer', 1, 1, @core:ADEOfAbstractDynamizer@);
 
 INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
-VALUES (25, null, 'ADEOfAbstractDynamizer', 1, 1, @core:ADEOfAbstractDynamizer@);
+VALUES (25, null, 'ADEOfAbstractFeature', 1, 1, @core:ADEOfAbstractFeature@);
 
 INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
 VALUES (26, null, 'ADEOfAbstractFeatureWithLifespan', 1, 1, @core:ADEOfAbstractFeatureWithLifespan@);
@@ -111,16 +111,10 @@ INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCH
 VALUES (36, null, 'ADEOfAbstractVersionTransition', 1, 1, @core:ADEOfAbstractVersionTransition@);
 
 INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
-VALUES (37, null, 'ADEOfAddress', 1, 1, @core:ADEOfAddress@);
+VALUES (37, null, 'ADEOfCityModel', 1, 1, @core:ADEOfCityModel@);
 
 INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
-VALUES (38, null, 'ADEOfCityModel', 1, 1, @core:ADEOfCityModel@);
-
-INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
-VALUES (39, null, 'ADEOfClosureSurface', 1, 1, @core:ADEOfClosureSurface@);
-
-INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
-VALUES (40, null, 'ADEOfImplicitGeometry', 1, 1, @core:ADEOfImplicitGeometry@);
+VALUES (38, null, 'ADEOfClosureSurface', 1, 1, @core:ADEOfClosureSurface@);
 
 -- Dynamizer Module --
 
@@ -184,7 +178,7 @@ VALUES (400, null, 'ADEOfPointCloud', 1, 5, @pcl:ADEOfPointCloud@);
 -- Relief Module --
 
 INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
-VALUES (500, null, 'ADEOfPointCloud', 1, 6, @dem:ADEOfAbstractReliefComponent@);
+VALUES (500, null, 'ADEOfAbstractReliefComponent', 1, 6, @dem:ADEOfAbstractReliefComponent@);
 
 INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
 VALUES (501, null, 'ADEOfBreaklineRelief', 1, 6, @dem:ADEOfBreaklineRelief@);
@@ -386,7 +380,7 @@ INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCH
 VALUES (1000, null, 'ADEOfAbstractBridge', 1, 11, @brid:ADEOfAbstractBridge@);
 
 INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
-VALUES (1001, null, 'ADEOfBridge', 1, 11, @bridADEOfBridge@);
+VALUES (1001, null, 'ADEOfBridge', 1, 11, @brid:ADEOfBridge@);
 
 INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
 VALUES (1002, null, 'ADEOfBridgeConstructiveElement', 1, 11, @brid:ADEOfBridgeConstructiveElement@);
@@ -402,26 +396,6 @@ VALUES (1005, null, 'ADEOfBridgePart', 1, 11, @brid:ADEOfBridgePart@);
 
 INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
 VALUES (1006, null, 'ADEOfBridgeRoom', 1, 11, @brid:ADEOfBridgeRoom@);
-
--- Appearance Module --
-
-INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
-VALUES (1100, null, 'ADEOfAbstractSurfaceData', 1, 12, @app:ADEOfAbstractSurfaceData@);
-
-INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
-VALUES (1101, null, 'ADEOfAbstractTexture', 1, 12, @app:ADEOfAbstractTexture@);
-
-INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
-VALUES (1102, null, 'ADEOfAppearance', 1, 12, @app:ADEOfAppearance@);
-
-INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
-VALUES (1103, null, 'ADEOfGeoreferencedTexture', 1, 12, @app:ADEOfGeoreferencedTexture@);
-
-INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
-VALUES (1104, null, 'ADEOfParameterizedTexture', 1, 12, @app:ADEOfParameterizedTexture@);
-
-INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
-VALUES (1105, null, 'ADEOfX3DMaterial', 1, 12, @app:ADEOfX3DMaterial@);
 
 -- CityObjectGroup Module --
 
@@ -471,4 +445,3 @@ VALUES (1503, null, 'ADEOfWaterSurface', 1, 16, @wtr:ADEOfWaterSurface@);
 
 INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
 VALUES (1600, null, 'ADEOfCityFurniture', 1, 17, @frn:ADEOfCityFurniture@);
-

--- a/postgresql/sql-scripts/schema/datatype-instances.sql
+++ b/postgresql/sql-scripts/schema/datatype-instances.sql
@@ -68,6 +68,60 @@ VALUES (21, null, 'QualifiedVolume', 0, 1, @core:QualifiedVolume@);
 INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
 VALUES (22, null, 'StringOrRef', 0, 1, @core:StringOrRef@);
 
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (23, null, 'ADEOfAbstractAppearance', 1, 1, @core:ADEOfAbstractAppearance@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (24, null, 'ADEOfAbstractCityObject', 1, 1, @core:ADEOfAbstractCityObject@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (25, null, 'ADEOfAbstractDynamizer', 1, 1, @core:ADEOfAbstractDynamizer@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (26, null, 'ADEOfAbstractFeatureWithLifespan', 1, 1, @core:ADEOfAbstractFeatureWithLifespan@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (27, null, 'ADEOfAbstractLogicalSpace', 1, 1, @core:ADEOfAbstractLogicalSpace@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (28, null, 'ADEOfAbstractOccupiedSpace', 1, 1, @core:ADEOfAbstractOccupiedSpace@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (29, null, 'ADEOfAbstractPhysicalSpace', 1, 1, @core:ADEOfAbstractPhysicalSpace@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (30, null, 'ADEOfAbstractPointCloud', 1, 1, @core:ADEOfAbstractPointCloud@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (31, null, 'ADEOfAbstractSpace', 1, 1, @core:ADEOfAbstractSpace@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (32, null, 'ADEOfAbstractSpaceBoundary', 1, 1, @core:ADEOfAbstractSpaceBoundary@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (33, null, 'ADEOfAbstractThematicSurface', 1, 1, @core:ADEOfAbstractThematicSurface@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (34, null, 'ADEOfAbstractUnoccupiedSpace', 1, 1, @core:ADEOfAbstractUnoccupiedSpace@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (35, null, 'ADEOfAbstractVersion', 1, 1, @core:ADEOfAbstractVersion@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (36, null, 'ADEOfAbstractVersionTransition', 1, 1, @core:ADEOfAbstractVersionTransition@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (37, null, 'ADEOfAddress', 1, 1, @core:ADEOfAddress@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (38, null, 'ADEOfCityModel', 1, 1, @core:ADEOfCityModel@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (39, null, 'ADEOfClosureSurface', 1, 1, @core:ADEOfClosureSurface@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (40, null, 'ADEOfImplicitGeometry', 1, 1, @core:ADEOfImplicitGeometry@);
+
 -- Dynamizer Module --
 
 INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
@@ -79,10 +133,123 @@ VALUES (101, null, 'TimeseriesComponent', 0, 2, @dyn:TimeseriesComponent@);
 INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
 VALUES (102, null, 'TimeValuePair', 0, 2, @dyn:TimeValuePair@);
 
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (103, null, 'ADEOfAbstractAtomicTimeseries', 1, 2, @dyn:ADEOfAbstractAtomicTimeseries@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (104, null, 'ADEOfAbstractTimeseries', 1, 2, @dyn:ADEOfAbstractTimeseries@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (105, null, 'ADEOfCompositeTimeseries', 1, 2, @dyn:ADEOfCompositeTimeseries@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (106, null, 'ADEOfDynamizer', 1, 2, @dyn:ADEOfDynamizer@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (107, null, 'ADEOfGenericTimeseries', 1, 2, @dyn:ADEOfGenericTimeseries@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (108, null, 'ADEOfStandardFileTimeseries', 1, 2, @dyn:ADEOfStandardFileTimeseries@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (109, null, 'ADEOfTabulatedFileTimeseries', 1, 2, @dyn:ADEOfTabulatedFileTimeseries@);
+
 -- Generics Module --
 
 INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
 VALUES (200, null, 'GenericAttributeSet', 0, 3, @gen:GenericAttributeSet@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (201, null, 'ADEOfGenericLogicalSpace', 1, 3, @gen:ADEOfGenericLogicalSpace@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (202, null, 'ADEOfGenericOccupiedSpace', 1, 3, @gen:ADEOfGenericOccupiedSpace@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (203, null, 'ADEOfGenericThematicSurface', 1, 3, @gen:ADEOfGenericThematicSurface@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (204, null, 'ADEOfGenericUnoccupiedSpace', 1, 3, @gen:ADEOfGenericUnoccupiedSpace@);
+
+-- LandUse Module --
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (300, null, 'ADEOfLandUse', 1, 4, @luse:ADEOfLandUse@);
+
+-- PointCloud Module --
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (400, null, 'ADEOfPointCloud', 1, 5, @pcl:ADEOfPointCloud@);
+
+-- Relief Module --
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (500, null, 'ADEOfPointCloud', 1, 6, @dem:ADEOfAbstractReliefComponent@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (501, null, 'ADEOfBreaklineRelief', 1, 6, @dem:ADEOfBreaklineRelief@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (502, null, 'ADEOfMassPointRelief', 1, 6, @dem:ADEOfMassPointRelief@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (503, null, 'ADEOfRasterRelief', 1, 6, @dem:ADEOfRasterRelief@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (504, null, 'ADEOfReliefFeature', 1, 6, @dem:ADEOfReliefFeature@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (505, null, 'ADEOfTINRelief', 1, 6, @dem:ADEOfTINRelief@);
+
+-- Transportation Module --
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (600, null, 'ADEOfAbstractTransportationSpace', 1, 7, @tran:ADEOfAbstractTransportationSpace@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (601, null, 'ADEOfAuxiliaryTrafficArea', 1, 7, @tran:ADEOfAuxiliaryTrafficArea@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (602, null, 'ADEOfAuxiliaryTrafficSpace', 1, 7, @tran:ADEOfAuxiliaryTrafficSpace@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (603, null, 'ADEOfClearanceSpace', 1, 7, @tran:ADEOfClearanceSpace@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (604, null, 'ADEOfHole', 1, 7, @tran:ADEOfHole@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (605, null, 'ADEOfHoleSurface', 1, 7, @tran:ADEOfHoleSurface@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (606, null, 'ADEOfIntersection', 1, 7, @tran:ADEOfIntersection@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (607, null, 'ADEOfMarking', 1, 7, @tran:ADEOfMarking@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (608, null, 'ADEOfRailway', 1, 7, @tran:ADEOfRailway@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (609, null, 'ADEOfRoad', 1, 7, @tran:ADEOfRoad@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (610, null, 'ADEOfSection', 1, 7, @tran:ADEOfSection@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (611, null, 'ADEOfSquare', 1, 7, @tran:ADEOfSquare@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (612, null, 'ADEOfTrack', 1, 7, @tran:ADEOfTrack@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (613, null, 'ADEOfTrafficArea', 1, 7, @tran:ADEOfTrafficArea@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (614, null, 'ADEOfTrafficSpace', 1, 7, @tran:ADEOfTrafficSpace@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (615, null, 'ADEOfWaterway', 1, 7, @tran:ADEOfWaterway@);
 
 -- Construction Module --
 
@@ -95,17 +262,213 @@ VALUES (701, null, 'Elevation', 0, 8, @con:Elevation@);
 INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
 VALUES (702, null, 'Height', 0, 8, @con:Height@);
 
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (703, null, 'ADEOfAbstractConstruction', 1, 8, @con:ADEOfAbstractConstruction@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (704, null, 'ADEOfAbstractConstructionSurface', 1, 8, @con:ADEOfAbstractConstructionSurface@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (705, null, 'ADEOfAbstractConstructiveElement', 1, 8, @con:ADEOfAbstractConstructiveElement@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (706, null, 'ADEOfAbstractFillingElement', 1, 8, @con:ADEOfAbstractFillingElement@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (707, null, 'ADEOfAbstractFillingSurface', 1, 8, @con:ADEOfAbstractFillingSurface@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (708, null, 'ADEOfAbstractFurniture', 1, 8, @con:ADEOfAbstractFurniture@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (709, null, 'ADEOfAbstractInstallation', 1, 8, @con:ADEOfAbstractInstallation@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (710, null, 'ADEOfCeilingSurface', 1, 8, @con:ADEOfCeilingSurface@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (711, null, 'ADEOfDoor', 1, 8, @con:ADEOfDoor@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (712, null, 'ADEOfDoorSurface', 1, 8, @con:ADEOfDoorSurface@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (713, null, 'ADEOfFloorSurface', 1, 8, @con:ADEOfFloorSurface@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (714, null, 'ADEOfGroundSurface', 1, 8, @con:ADEOfGroundSurface@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (715, null, 'ADEOfInteriorWallSurface', 1, 8, @con:ADEOfInteriorWallSurface@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (716, null, 'ADEOfOtherConstruction', 1, 8, @con:ADEOfOtherConstruction@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (717, null, 'ADEOfOuterCeilingSurface', 1, 8, @con:ADEOfOuterCeilingSurface@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (718, null, 'ADEOfOuterFloorSurface', 1, 8, @con:ADEOfOuterFloorSurface@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (719, null, 'ADEOfRoofSurface', 1, 8, @con:ADEOfRoofSurface@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (720, null, 'ADEOfWallSurface', 1, 8, @con:ADEOfWallSurface@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (721, null, 'ADEOfWindow', 1, 8, @con:ADEOfWindow@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (722, null, 'ADEOfWindowSurface', 1, 8, @con:ADEOfWindowSurface@);
+
+-- Tunnel Module --
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (800, null, 'ADEOfAbstractTunnel', 1, 9, @tun:ADEOfAbstractTunnel@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (801, null, 'ADEOfHollowSpace', 1, 9, @tun:ADEOfHollowSpace@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (802, null, 'ADEOfTunnel', 1, 9, @tun:ADEOfTunnel@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (803, null, 'ADEOfTunnelConstructiveElement', 1, 9, @tun:ADEOfTunnelConstructiveElement@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (804, null, 'ADEOfTunnelFurniture', 1, 9, @tun:ADEOfTunnelFurniture@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (805, null, 'ADEOfTunnelInstallation', 1, 9, @tun:ADEOfTunnelInstallation@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (806, null, 'ADEOfTunnelPart', 1, 9, @tun:ADEOfTunnelPart@);
+
 -- Building Module --
 
 INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
 VALUES (900, null, 'RoomHeight', 0, 10, @bldg:RoomHeight@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (901, null, 'ADEOfAbstractBuilding', 1, 10, @bldg:ADEOfAbstractBuilding@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (902, null, 'ADEOfAbstractBuildingSubdivision', 1, 10, @bldg:ADEOfAbstractBuildingSubdivision@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (903, null, 'ADEOfBuilding', 1, 10, @bldg:ADEOfBuilding@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (904, null, 'ADEOfBuildingConstructiveElement', 1, 10, @bldg:ADEOfBuildingConstructiveElement@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (905, null, 'ADEOfBuildingFurniture', 1, 10, @bldg:ADEOfBuildingFurniture@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (906, null, 'ADEOfBuildingInstallation', 1, 10, @bldg:ADEOfBuildingInstallation@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (907, null, 'ADEOfBuildingPart', 1, 10, @bldg:ADEOfBuildingPart@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (908, null, 'ADEOfBuildingRoom', 1, 10, @bldg:ADEOfBuildingRoom@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (909, null, 'ADEOfBuildingUnit', 1, 10, @bldg:ADEOfBuildingUnit@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (910, null, 'ADEOfStorey', 1, 10, @bldg:ADEOfStorey@);
+
+-- Bridge Module --
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (1000, null, 'ADEOfAbstractBridge', 1, 11, @brid:ADEOfAbstractBridge@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (1001, null, 'ADEOfBridge', 1, 11, @bridADEOfBridge@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (1002, null, 'ADEOfBridgeConstructiveElement', 1, 11, @brid:ADEOfBridgeConstructiveElement@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (1003, null, 'ADEOfBridgeFurniture', 1, 11, @brid:ADEOfBridgeFurniture@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (1004, null, 'ADEOfBridgeInstallation', 1, 11, @brid:ADEOfBridgeInstallation@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (1005, null, 'ADEOfBridgePart', 1, 11, @brid:ADEOfBridgePart@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (1006, null, 'ADEOfBridgeRoom', 1, 11, @brid:ADEOfBridgeRoom@);
+
+-- Appearance Module --
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (1100, null, 'ADEOfAbstractSurfaceData', 1, 12, @app:ADEOfAbstractSurfaceData@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (1101, null, 'ADEOfAbstractTexture', 1, 12, @app:ADEOfAbstractTexture@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (1102, null, 'ADEOfAppearance', 1, 12, @app:ADEOfAppearance@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (1103, null, 'ADEOfGeoreferencedTexture', 1, 12, @app:ADEOfGeoreferencedTexture@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (1104, null, 'ADEOfParameterizedTexture', 1, 12, @app:ADEOfParameterizedTexture@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (1105, null, 'ADEOfX3DMaterial', 1, 12, @app:ADEOfX3DMaterial@);
 
 -- CityObjectGroup Module --
 
 INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
 VALUES (1200, null, 'Role', 0, 13, @grp:Role@);
 
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (1201, null, 'ADEOfCityObjectGroup', 1, 13, @grp:ADEOfCityObjectGroup@);
+
+-- Vegetation Module --
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (1300, null, 'ADEOfAbstractVegetationObject', 1, 14, @veg:ADEOfAbstractVegetationObject@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (1301, null, 'ADEOfPlantCover', 1, 14, @veg:ADEOfPlantCover@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (1302, null, 'ADEOfSolitaryVegetationObject', 1, 14, @veg:ADEOfSolitaryVegetationObject@);
+
 -- Versioning Module --
 
 INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
 VALUES (1400, null, 'Transaction', 0, 15, @vers:Transaction@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (1401, null, 'ADEOfVersion', 1, 15, @vers:ADEOfVersion@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (1402, null, 'ADEOfVersionTransition', 1, 15, @vers:ADEOfVersionTransition@);
+
+-- WaterBody Module --
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (1500, null, 'ADEOfAbstractWaterBoundarySurface', 1, 16, @wtr:ADEOfAbstractWaterBoundarySurface@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (1501, null, 'ADEOfWaterBody', 1, 16, @wtr:ADEOfWaterBody@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (1502, null, 'ADEOfWaterGroundSurface', 1, 16, @wtr:ADEOfWaterGroundSurface@);
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (1503, null, 'ADEOfWaterSurface', 1, 16, @wtr:ADEOfWaterSurface@);
+
+-- CityFurniture Module --
+
+INSERT INTO datatype (ID, SUPERTYPE_ID, TYPENAME, IS_ABSTRACT, NAMESPACE_ID, SCHEMA)
+VALUES (1600, null, 'ADEOfCityFurniture', 1, 17, @frn:ADEOfCityFurniture@);
+

--- a/schema-mapping/data-types/appearance/ADEOfAbstractSurfaceData.json
+++ b/schema-mapping/data-types/appearance/ADEOfAbstractSurfaceData.json
@@ -1,4 +1,0 @@
-{
-  "identifier": "app:ADEOfAbstractSurfaceData",
-  "table": "property"
-}

--- a/schema-mapping/data-types/appearance/ADEOfAbstractSurfaceData.json
+++ b/schema-mapping/data-types/appearance/ADEOfAbstractSurfaceData.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "app:ADEOfAbstractSurfaceData",
+  "table": "property"
+}

--- a/schema-mapping/data-types/appearance/ADEOfAbstractTexture.json
+++ b/schema-mapping/data-types/appearance/ADEOfAbstractTexture.json
@@ -1,4 +1,0 @@
-{
-  "identifier": "app:ADEOfAbstractTexture",
-  "table": "property"
-}

--- a/schema-mapping/data-types/appearance/ADEOfAbstractTexture.json
+++ b/schema-mapping/data-types/appearance/ADEOfAbstractTexture.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "app:ADEOfAbstractTexture",
+  "table": "property"
+}

--- a/schema-mapping/data-types/appearance/ADEOfAppearance.json
+++ b/schema-mapping/data-types/appearance/ADEOfAppearance.json
@@ -1,4 +1,0 @@
-{
-  "identifier": "app:ADEOfAppearance",
-  "table": "property"
-}

--- a/schema-mapping/data-types/appearance/ADEOfAppearance.json
+++ b/schema-mapping/data-types/appearance/ADEOfAppearance.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "app:ADEOfAppearance",
+  "table": "property"
+}

--- a/schema-mapping/data-types/appearance/ADEOfGeoreferencedTexture.json
+++ b/schema-mapping/data-types/appearance/ADEOfGeoreferencedTexture.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "app:ADEOfGeoreferencedTexture",
+  "table": "property"
+}

--- a/schema-mapping/data-types/appearance/ADEOfGeoreferencedTexture.json
+++ b/schema-mapping/data-types/appearance/ADEOfGeoreferencedTexture.json
@@ -1,4 +1,0 @@
-{
-  "identifier": "app:ADEOfGeoreferencedTexture",
-  "table": "property"
-}

--- a/schema-mapping/data-types/appearance/ADEOfParameterizedTexture.json
+++ b/schema-mapping/data-types/appearance/ADEOfParameterizedTexture.json
@@ -1,4 +1,0 @@
-{
-  "identifier": "app:ADEOfParameterizedTexture",
-  "table": "property"
-}

--- a/schema-mapping/data-types/appearance/ADEOfParameterizedTexture.json
+++ b/schema-mapping/data-types/appearance/ADEOfParameterizedTexture.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "app:ADEOfParameterizedTexture",
+  "table": "property"
+}

--- a/schema-mapping/data-types/appearance/ADEOfX3DMaterial.json
+++ b/schema-mapping/data-types/appearance/ADEOfX3DMaterial.json
@@ -1,4 +1,0 @@
-{
-  "identifier": "app:ADEOfX3DMaterial",
-  "table": "property"
-}

--- a/schema-mapping/data-types/appearance/ADEOfX3DMaterial.json
+++ b/schema-mapping/data-types/appearance/ADEOfX3DMaterial.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "app:ADEOfX3DMaterial",
+  "table": "property"
+}

--- a/schema-mapping/data-types/bridge/ADEOfAbstractBridge.json
+++ b/schema-mapping/data-types/bridge/ADEOfAbstractBridge.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "brid:ADEOfAbstractBridge",
+  "table": "property"
+}

--- a/schema-mapping/data-types/bridge/ADEOfBridge.json
+++ b/schema-mapping/data-types/bridge/ADEOfBridge.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "brid:ADEOfBridge",
+  "table": "property"
+}

--- a/schema-mapping/data-types/bridge/ADEOfBridgeConstructiveElement.json
+++ b/schema-mapping/data-types/bridge/ADEOfBridgeConstructiveElement.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "brid:ADEOfBridgeConstructiveElement",
+  "table": "property"
+}

--- a/schema-mapping/data-types/bridge/ADEOfBridgeFurniture.json
+++ b/schema-mapping/data-types/bridge/ADEOfBridgeFurniture.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "brid:ADEOfBridgeFurniture",
+  "table": "property"
+}

--- a/schema-mapping/data-types/bridge/ADEOfBridgeInstallation.json
+++ b/schema-mapping/data-types/bridge/ADEOfBridgeInstallation.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "brid:ADEOfBridgeInstallation",
+  "table": "property"
+}

--- a/schema-mapping/data-types/bridge/ADEOfBridgePart.json
+++ b/schema-mapping/data-types/bridge/ADEOfBridgePart.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "brid:ADEOfBridgePart",
+  "table": "property"
+}

--- a/schema-mapping/data-types/bridge/ADEOfBridgeRoom.json
+++ b/schema-mapping/data-types/bridge/ADEOfBridgeRoom.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "brid:ADEOfBridgeRoom",
+  "table": "property"
+}

--- a/schema-mapping/data-types/building/ADEOfAbstractBuilding.json
+++ b/schema-mapping/data-types/building/ADEOfAbstractBuilding.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "bldg:ADEOfAbstractBuilding",
+  "table": "property"
+}

--- a/schema-mapping/data-types/building/ADEOfAbstractBuildingSubdivision.json
+++ b/schema-mapping/data-types/building/ADEOfAbstractBuildingSubdivision.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "bldg:ADEOfAbstractBuildingSubdivision",
+  "table": "property"
+}

--- a/schema-mapping/data-types/building/ADEOfBuilding.json
+++ b/schema-mapping/data-types/building/ADEOfBuilding.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "bldg:ADEOfBuilding",
+  "table": "property"
+}

--- a/schema-mapping/data-types/building/ADEOfBuildingConstructiveElement.json
+++ b/schema-mapping/data-types/building/ADEOfBuildingConstructiveElement.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "bldg:ADEOfBuildingConstructiveElement",
+  "table": "property"
+}

--- a/schema-mapping/data-types/building/ADEOfBuildingFurniture.json
+++ b/schema-mapping/data-types/building/ADEOfBuildingFurniture.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "bldg:ADEOfBuildingFurniture",
+  "table": "property"
+}

--- a/schema-mapping/data-types/building/ADEOfBuildingInstallation.json
+++ b/schema-mapping/data-types/building/ADEOfBuildingInstallation.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "bldg:ADEOfBuildingInstallation",
+  "table": "property"
+}

--- a/schema-mapping/data-types/building/ADEOfBuildingPart.json
+++ b/schema-mapping/data-types/building/ADEOfBuildingPart.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "bldg:ADEOfBuildingPart",
+  "table": "property"
+}

--- a/schema-mapping/data-types/building/ADEOfBuildingRoom.json
+++ b/schema-mapping/data-types/building/ADEOfBuildingRoom.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "bldg:ADEOfBuildingRoom",
+  "table": "property"
+}

--- a/schema-mapping/data-types/building/ADEOfBuildingUnit.json
+++ b/schema-mapping/data-types/building/ADEOfBuildingUnit.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "bldg:ADEOfBuildingUnit",
+  "table": "property"
+}

--- a/schema-mapping/data-types/building/ADEOfStorey.json
+++ b/schema-mapping/data-types/building/ADEOfStorey.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "bldg:ADEOfStorey",
+  "table": "property"
+}

--- a/schema-mapping/data-types/cityfurniture/ADEOfCityFurniture.json
+++ b/schema-mapping/data-types/cityfurniture/ADEOfCityFurniture.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "frn:ADEOfCityFurniture",
+  "table": "property"
+}

--- a/schema-mapping/data-types/cityobjectgroup/ADEOfCityObjectGroup.json
+++ b/schema-mapping/data-types/cityobjectgroup/ADEOfCityObjectGroup.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "grp:ADEOfCityObjectGroup",
+  "table": "property"
+}

--- a/schema-mapping/data-types/construction/ADEOfAbstractConstruction.json
+++ b/schema-mapping/data-types/construction/ADEOfAbstractConstruction.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "con:ADEOfAbstractConstruction",
+  "table": "property"
+}

--- a/schema-mapping/data-types/construction/ADEOfAbstractConstructionSurface.json
+++ b/schema-mapping/data-types/construction/ADEOfAbstractConstructionSurface.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "con:ADEOfAbstractConstructionSurface",
+  "table": "property"
+}

--- a/schema-mapping/data-types/construction/ADEOfAbstractConstructiveElement.json
+++ b/schema-mapping/data-types/construction/ADEOfAbstractConstructiveElement.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "con:ADEOfAbstractConstructiveElement",
+  "table": "property"
+}

--- a/schema-mapping/data-types/construction/ADEOfAbstractFillingElement.json
+++ b/schema-mapping/data-types/construction/ADEOfAbstractFillingElement.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "con:ADEOfAbstractFillingElement",
+  "table": "property"
+}

--- a/schema-mapping/data-types/construction/ADEOfAbstractFillingSurface.json
+++ b/schema-mapping/data-types/construction/ADEOfAbstractFillingSurface.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "con:ADEOfAbstractFillingSurface",
+  "table": "property"
+}

--- a/schema-mapping/data-types/construction/ADEOfAbstractFurniture.json
+++ b/schema-mapping/data-types/construction/ADEOfAbstractFurniture.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "con:ADEOfAbstractFurniture",
+  "table": "property"
+}

--- a/schema-mapping/data-types/construction/ADEOfAbstractInstallation.json
+++ b/schema-mapping/data-types/construction/ADEOfAbstractInstallation.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "con:ADEOfAbstractInstallation",
+  "table": "property"
+}

--- a/schema-mapping/data-types/construction/ADEOfCeilingSurface.json
+++ b/schema-mapping/data-types/construction/ADEOfCeilingSurface.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "con:ADEOfCeilingSurface",
+  "table": "property"
+}

--- a/schema-mapping/data-types/construction/ADEOfDoor.json
+++ b/schema-mapping/data-types/construction/ADEOfDoor.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "con:ADEOfDoor",
+  "table": "property"
+}

--- a/schema-mapping/data-types/construction/ADEOfDoorSurface.json
+++ b/schema-mapping/data-types/construction/ADEOfDoorSurface.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "con:ADEOfDoorSurface",
+  "table": "property"
+}

--- a/schema-mapping/data-types/construction/ADEOfFloorSurface.json
+++ b/schema-mapping/data-types/construction/ADEOfFloorSurface.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "con:ADEOfFloorSurface",
+  "table": "property"
+}

--- a/schema-mapping/data-types/construction/ADEOfGroundSurface.json
+++ b/schema-mapping/data-types/construction/ADEOfGroundSurface.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "con:ADEOfGroundSurface",
+  "table": "property"
+}

--- a/schema-mapping/data-types/construction/ADEOfInteriorWallSurface.json
+++ b/schema-mapping/data-types/construction/ADEOfInteriorWallSurface.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "con:ADEOfInteriorWallSurface",
+  "table": "property"
+}

--- a/schema-mapping/data-types/construction/ADEOfOtherConstruction.json
+++ b/schema-mapping/data-types/construction/ADEOfOtherConstruction.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "con:ADEOfOtherConstruction",
+  "table": "property"
+}

--- a/schema-mapping/data-types/construction/ADEOfOuterCeilingSurface.json
+++ b/schema-mapping/data-types/construction/ADEOfOuterCeilingSurface.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "con:ADEOfOuterCeilingSurface",
+  "table": "property"
+}

--- a/schema-mapping/data-types/construction/ADEOfOuterFloorSurface.json
+++ b/schema-mapping/data-types/construction/ADEOfOuterFloorSurface.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "con:ADEOfOuterFloorSurface",
+  "table": "property"
+}

--- a/schema-mapping/data-types/construction/ADEOfRoofSurface.json
+++ b/schema-mapping/data-types/construction/ADEOfRoofSurface.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "con:ADEOfRoofSurface",
+  "table": "property"
+}

--- a/schema-mapping/data-types/construction/ADEOfWallSurface.json
+++ b/schema-mapping/data-types/construction/ADEOfWallSurface.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "con:ADEOfWallSurface",
+  "table": "property"
+}

--- a/schema-mapping/data-types/construction/ADEOfWindow.json
+++ b/schema-mapping/data-types/construction/ADEOfWindow.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "con:ADEOfWindow",
+  "table": "property"
+}

--- a/schema-mapping/data-types/construction/ADEOfWindowSurface.json
+++ b/schema-mapping/data-types/construction/ADEOfWindowSurface.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "con:ADEOfWindowSurface",
+  "table": "property"
+}

--- a/schema-mapping/data-types/core/ADEOfAbstractAppearance.json
+++ b/schema-mapping/data-types/core/ADEOfAbstractAppearance.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "core:ADEOfAbstractAppearance",
+  "table": "property"
+}

--- a/schema-mapping/data-types/core/ADEOfAbstractAppearance.json
+++ b/schema-mapping/data-types/core/ADEOfAbstractAppearance.json
@@ -1,4 +1,0 @@
-{
-  "identifier": "core:ADEOfAbstractAppearance",
-  "table": "property"
-}

--- a/schema-mapping/data-types/core/ADEOfAbstractCityObject.json
+++ b/schema-mapping/data-types/core/ADEOfAbstractCityObject.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "core:ADEOfAbstractCityObject",
+  "table": "property"
+}

--- a/schema-mapping/data-types/core/ADEOfAbstractDynamizer.json
+++ b/schema-mapping/data-types/core/ADEOfAbstractDynamizer.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "core:ADEOfAbstractDynamizer",
+  "table": "property"
+}

--- a/schema-mapping/data-types/core/ADEOfAbstractFeature.json
+++ b/schema-mapping/data-types/core/ADEOfAbstractFeature.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "core:ADEOfAbstractFeature",
+  "table": "property"
+}

--- a/schema-mapping/data-types/core/ADEOfAbstractFeatureWithLifespan.json
+++ b/schema-mapping/data-types/core/ADEOfAbstractFeatureWithLifespan.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "core:ADEOfAbstractFeatureWithLifespan",
+  "table": "property"
+}

--- a/schema-mapping/data-types/core/ADEOfAbstractLogicalSpace.json
+++ b/schema-mapping/data-types/core/ADEOfAbstractLogicalSpace.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "core:ADEOfAbstractLogicalSpace",
+  "table": "property"
+}

--- a/schema-mapping/data-types/core/ADEOfAbstractOccupiedSpace.json
+++ b/schema-mapping/data-types/core/ADEOfAbstractOccupiedSpace.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "core:ADEOfAbstractOccupiedSpace",
+  "table": "property"
+}

--- a/schema-mapping/data-types/core/ADEOfAbstractPhysicalSpace.json
+++ b/schema-mapping/data-types/core/ADEOfAbstractPhysicalSpace.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "core:ADEOfAbstractPhysicalSpace",
+  "table": "property"
+}

--- a/schema-mapping/data-types/core/ADEOfAbstractPointCloud.json
+++ b/schema-mapping/data-types/core/ADEOfAbstractPointCloud.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "core:ADEOfAbstractPointCloud",
+  "table": "property"
+}

--- a/schema-mapping/data-types/core/ADEOfAbstractSpace.json
+++ b/schema-mapping/data-types/core/ADEOfAbstractSpace.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "core:ADEOfAbstractSpace",
+  "table": "property"
+}

--- a/schema-mapping/data-types/core/ADEOfAbstractSpaceBoundary.json
+++ b/schema-mapping/data-types/core/ADEOfAbstractSpaceBoundary.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "core:ADEOfAbstractSpaceBoundary",
+  "table": "property"
+}

--- a/schema-mapping/data-types/core/ADEOfAbstractThematicSurface.json
+++ b/schema-mapping/data-types/core/ADEOfAbstractThematicSurface.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "core:ADEOfAbstractThematicSurface",
+  "table": "property"
+}

--- a/schema-mapping/data-types/core/ADEOfAbstractUnoccupiedSpace.json
+++ b/schema-mapping/data-types/core/ADEOfAbstractUnoccupiedSpace.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "core:ADEOfAbstractUnoccupiedSpace",
+  "table": "property"
+}

--- a/schema-mapping/data-types/core/ADEOfAbstractVersion.json
+++ b/schema-mapping/data-types/core/ADEOfAbstractVersion.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "core:ADEOfAbstractVersion",
+  "table": "property"
+}

--- a/schema-mapping/data-types/core/ADEOfAbstractVersionTransition.json
+++ b/schema-mapping/data-types/core/ADEOfAbstractVersionTransition.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "core:ADEOfAbstractVersionTransition",
+  "table": "property"
+}

--- a/schema-mapping/data-types/core/ADEOfAddress.json
+++ b/schema-mapping/data-types/core/ADEOfAddress.json
@@ -1,4 +1,0 @@
-{
-  "identifier": "core:ADEOfAddress",
-  "table": "property"
-}

--- a/schema-mapping/data-types/core/ADEOfAddress.json
+++ b/schema-mapping/data-types/core/ADEOfAddress.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "core:ADEOfAddress",
+  "table": "property"
+}

--- a/schema-mapping/data-types/core/ADEOfCityModel.json
+++ b/schema-mapping/data-types/core/ADEOfCityModel.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "core:ADEOfCityModel",
+  "table": "property"
+}

--- a/schema-mapping/data-types/core/ADEOfClosureSurface.json
+++ b/schema-mapping/data-types/core/ADEOfClosureSurface.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "core:ADEOfClosureSurface",
+  "table": "property"
+}

--- a/schema-mapping/data-types/core/ADEOfImplicitGeometry.json
+++ b/schema-mapping/data-types/core/ADEOfImplicitGeometry.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "core:ADEOfImplicitGeometry",
+  "table": "property"
+}

--- a/schema-mapping/data-types/core/ADEOfImplicitGeometry.json
+++ b/schema-mapping/data-types/core/ADEOfImplicitGeometry.json
@@ -1,4 +1,0 @@
-{
-  "identifier": "core:ADEOfImplicitGeometry",
-  "table": "property"
-}

--- a/schema-mapping/data-types/dynamizer/ADEOfAbstractAtomicTimeseries.json
+++ b/schema-mapping/data-types/dynamizer/ADEOfAbstractAtomicTimeseries.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "dyn:ADEOfAbstractAtomicTimeseries",
+  "table": "property"
+}

--- a/schema-mapping/data-types/dynamizer/ADEOfAbstractTimeseries.json
+++ b/schema-mapping/data-types/dynamizer/ADEOfAbstractTimeseries.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "dyn:ADEOfAbstractTimeseries",
+  "table": "property"
+}

--- a/schema-mapping/data-types/dynamizer/ADEOfCompositeTimeseries.json
+++ b/schema-mapping/data-types/dynamizer/ADEOfCompositeTimeseries.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "dyn:ADEOfCompositeTimeseries",
+  "table": "property"
+}

--- a/schema-mapping/data-types/dynamizer/ADEOfDynamizer.json
+++ b/schema-mapping/data-types/dynamizer/ADEOfDynamizer.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "dyn:ADEOfDynamizer",
+  "table": "property"
+}

--- a/schema-mapping/data-types/dynamizer/ADEOfGenericTimeseries.json
+++ b/schema-mapping/data-types/dynamizer/ADEOfGenericTimeseries.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "dyn:ADEOfGenericTimeseries",
+  "table": "property"
+}

--- a/schema-mapping/data-types/dynamizer/ADEOfStandardFileTimeseries.json
+++ b/schema-mapping/data-types/dynamizer/ADEOfStandardFileTimeseries.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "dyn:ADEOfStandardFileTimeseries",
+  "table": "property"
+}

--- a/schema-mapping/data-types/dynamizer/ADEOfTabulatedFileTimeseries.json
+++ b/schema-mapping/data-types/dynamizer/ADEOfTabulatedFileTimeseries.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "dyn:ADEOfTabulatedFileTimeseries",
+  "table": "property"
+}

--- a/schema-mapping/data-types/generics/ADEOfGenericLogicalSpace.json
+++ b/schema-mapping/data-types/generics/ADEOfGenericLogicalSpace.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "gen:ADEOfGenericLogicalSpace",
+  "table": "property"
+}

--- a/schema-mapping/data-types/generics/ADEOfGenericOccupiedSpace.json
+++ b/schema-mapping/data-types/generics/ADEOfGenericOccupiedSpace.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "gen:ADEOfGenericOccupiedSpace",
+  "table": "property"
+}

--- a/schema-mapping/data-types/generics/ADEOfGenericThematicSurface.json
+++ b/schema-mapping/data-types/generics/ADEOfGenericThematicSurface.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "gen:ADEOfGenericThematicSurface",
+  "table": "property"
+}

--- a/schema-mapping/data-types/generics/ADEOfGenericUnoccupiedSpace.json
+++ b/schema-mapping/data-types/generics/ADEOfGenericUnoccupiedSpace.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "gen:ADEOfGenericUnoccupiedSpace",
+  "table": "property"
+}

--- a/schema-mapping/data-types/landuse/ADEOfLandUse.json
+++ b/schema-mapping/data-types/landuse/ADEOfLandUse.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "luse:ADEOfLandUse",
+  "table": "property"
+}

--- a/schema-mapping/data-types/pointcloud/ADEOfPointCloud.json
+++ b/schema-mapping/data-types/pointcloud/ADEOfPointCloud.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "pcl:ADEOfPointCloud",
+  "table": "property"
+}

--- a/schema-mapping/data-types/relief/ADEOfAbstractReliefComponent.json
+++ b/schema-mapping/data-types/relief/ADEOfAbstractReliefComponent.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "dem:ADEOfAbstractReliefComponent",
+  "table": "property"
+}

--- a/schema-mapping/data-types/relief/ADEOfBreaklineRelief.json
+++ b/schema-mapping/data-types/relief/ADEOfBreaklineRelief.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "dem:ADEOfBreaklineRelief",
+  "table": "property"
+}

--- a/schema-mapping/data-types/relief/ADEOfMassPointRelief.json
+++ b/schema-mapping/data-types/relief/ADEOfMassPointRelief.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "dem:ADEOfMassPointRelief",
+  "table": "property"
+}

--- a/schema-mapping/data-types/relief/ADEOfRasterRelief.json
+++ b/schema-mapping/data-types/relief/ADEOfRasterRelief.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "dem:ADEOfRasterRelief",
+  "table": "property"
+}

--- a/schema-mapping/data-types/relief/ADEOfReliefFeature.json
+++ b/schema-mapping/data-types/relief/ADEOfReliefFeature.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "dem:ADEOfReliefFeature",
+  "table": "property"
+}

--- a/schema-mapping/data-types/relief/ADEOfTINRelief.json
+++ b/schema-mapping/data-types/relief/ADEOfTINRelief.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "dem:ADEOfTINRelief",
+  "table": "property"
+}

--- a/schema-mapping/data-types/transportation/ADEOfAbstractTransportationSpace.json
+++ b/schema-mapping/data-types/transportation/ADEOfAbstractTransportationSpace.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "tran:ADEOfAbstractTransportationSpace",
+  "table": "property"
+}

--- a/schema-mapping/data-types/transportation/ADEOfAuxiliaryTrafficArea.json
+++ b/schema-mapping/data-types/transportation/ADEOfAuxiliaryTrafficArea.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "tran:ADEOfAuxiliaryTrafficArea",
+  "table": "property"
+}

--- a/schema-mapping/data-types/transportation/ADEOfAuxiliaryTrafficSpace.json
+++ b/schema-mapping/data-types/transportation/ADEOfAuxiliaryTrafficSpace.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "tran:ADEOfAuxiliaryTrafficSpace",
+  "table": "property"
+}

--- a/schema-mapping/data-types/transportation/ADEOfClearanceSpace.json
+++ b/schema-mapping/data-types/transportation/ADEOfClearanceSpace.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "tran:ADEOfClearanceSpace",
+  "table": "property"
+}

--- a/schema-mapping/data-types/transportation/ADEOfHole.json
+++ b/schema-mapping/data-types/transportation/ADEOfHole.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "tran:ADEOfHole",
+  "table": "property"
+}

--- a/schema-mapping/data-types/transportation/ADEOfHoleSurface.json
+++ b/schema-mapping/data-types/transportation/ADEOfHoleSurface.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "tran:ADEOfHoleSurface",
+  "table": "property"
+}

--- a/schema-mapping/data-types/transportation/ADEOfIntersection.json
+++ b/schema-mapping/data-types/transportation/ADEOfIntersection.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "tran:ADEOfIntersection",
+  "table": "property"
+}

--- a/schema-mapping/data-types/transportation/ADEOfMarking.json
+++ b/schema-mapping/data-types/transportation/ADEOfMarking.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "tran:ADEOfMarking",
+  "table": "property"
+}

--- a/schema-mapping/data-types/transportation/ADEOfRailway.json
+++ b/schema-mapping/data-types/transportation/ADEOfRailway.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "tran:ADEOfRailway",
+  "table": "property"
+}

--- a/schema-mapping/data-types/transportation/ADEOfRoad.json
+++ b/schema-mapping/data-types/transportation/ADEOfRoad.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "tran:ADEOfRoad",
+  "table": "property"
+}

--- a/schema-mapping/data-types/transportation/ADEOfSection.json
+++ b/schema-mapping/data-types/transportation/ADEOfSection.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "tran:ADEOfSection",
+  "table": "property"
+}

--- a/schema-mapping/data-types/transportation/ADEOfSquare.json
+++ b/schema-mapping/data-types/transportation/ADEOfSquare.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "tran:ADEOfSquare",
+  "table": "property"
+}

--- a/schema-mapping/data-types/transportation/ADEOfTrack.json
+++ b/schema-mapping/data-types/transportation/ADEOfTrack.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "tran:ADEOfTrack",
+  "table": "property"
+}

--- a/schema-mapping/data-types/transportation/ADEOfTrafficArea.json
+++ b/schema-mapping/data-types/transportation/ADEOfTrafficArea.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "tran:ADEOfTrafficArea",
+  "table": "property"
+}

--- a/schema-mapping/data-types/transportation/ADEOfTrafficSpace.json
+++ b/schema-mapping/data-types/transportation/ADEOfTrafficSpace.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "tran:ADEOfTrafficSpace",
+  "table": "property"
+}

--- a/schema-mapping/data-types/transportation/ADEOfWaterway.json
+++ b/schema-mapping/data-types/transportation/ADEOfWaterway.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "tran:ADEOfWaterway",
+  "table": "property"
+}

--- a/schema-mapping/data-types/tunnel/ADEOfAbstractTunnel.json
+++ b/schema-mapping/data-types/tunnel/ADEOfAbstractTunnel.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "tun:ADEOfAbstractTunnel",
+  "table": "property"
+}

--- a/schema-mapping/data-types/tunnel/ADEOfHollowSpace.json
+++ b/schema-mapping/data-types/tunnel/ADEOfHollowSpace.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "tun:ADEOfHollowSpace",
+  "table": "property"
+}

--- a/schema-mapping/data-types/tunnel/ADEOfTunnel.json
+++ b/schema-mapping/data-types/tunnel/ADEOfTunnel.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "tun:ADEOfTunnel",
+  "table": "property"
+}

--- a/schema-mapping/data-types/tunnel/ADEOfTunnelConstructiveElement.json
+++ b/schema-mapping/data-types/tunnel/ADEOfTunnelConstructiveElement.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "tun:ADEOfTunnelConstructiveElement",
+  "table": "property"
+}

--- a/schema-mapping/data-types/tunnel/ADEOfTunnelFurniture.json
+++ b/schema-mapping/data-types/tunnel/ADEOfTunnelFurniture.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "tun:ADEOfAbstractTunnel",
+  "table": "property"
+}

--- a/schema-mapping/data-types/tunnel/ADEOfTunnelFurniture.json
+++ b/schema-mapping/data-types/tunnel/ADEOfTunnelFurniture.json
@@ -1,4 +1,4 @@
 {
-  "identifier": "tun:ADEOfAbstractTunnel",
+  "identifier": "tun:ADEOfTunnelFurniture",
   "table": "property"
 }

--- a/schema-mapping/data-types/tunnel/ADEOfTunnelInstallation.json
+++ b/schema-mapping/data-types/tunnel/ADEOfTunnelInstallation.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "tun:ADEOfTunnelFurniture",
+  "table": "property"
+}

--- a/schema-mapping/data-types/tunnel/ADEOfTunnelInstallation.json
+++ b/schema-mapping/data-types/tunnel/ADEOfTunnelInstallation.json
@@ -1,4 +1,4 @@
 {
-  "identifier": "tun:ADEOfTunnelFurniture",
+  "identifier": "tun:ADEOfTunnelInstallation",
   "table": "property"
 }

--- a/schema-mapping/data-types/tunnel/ADEOfTunnelPart.json
+++ b/schema-mapping/data-types/tunnel/ADEOfTunnelPart.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "tun:ADEOfTunnelPart",
+  "table": "property"
+}

--- a/schema-mapping/data-types/vegetation/ADEOfAbstractVegetationObject.json
+++ b/schema-mapping/data-types/vegetation/ADEOfAbstractVegetationObject.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "veg:ADEOfAbstractVegetationObject",
+  "table": "property"
+}

--- a/schema-mapping/data-types/vegetation/ADEOfPlantCover.json
+++ b/schema-mapping/data-types/vegetation/ADEOfPlantCover.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "veg:ADEOfPlantCover",
+  "table": "property"
+}

--- a/schema-mapping/data-types/vegetation/ADEOfSolitaryVegetationObject.json
+++ b/schema-mapping/data-types/vegetation/ADEOfSolitaryVegetationObject.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "veg:ADEOfSolitaryVegetationObject",
+  "table": "property"
+}

--- a/schema-mapping/data-types/versioning/ADEOfVersion.json
+++ b/schema-mapping/data-types/versioning/ADEOfVersion.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "vers:ADEOfVersion",
+  "table": "property"
+}

--- a/schema-mapping/data-types/versioning/ADEOfVersionTransition.json
+++ b/schema-mapping/data-types/versioning/ADEOfVersionTransition.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "vers:ADEOfVersionTransition",
+  "table": "property"
+}

--- a/schema-mapping/data-types/waterbody/ADEOfAbstractWaterBoundarySurface.json
+++ b/schema-mapping/data-types/waterbody/ADEOfAbstractWaterBoundarySurface.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "wtr:ADEOfAbstractWaterBoundarySurface",
+  "table": "property"
+}

--- a/schema-mapping/data-types/waterbody/ADEOfWaterBody.json
+++ b/schema-mapping/data-types/waterbody/ADEOfWaterBody.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "wtr:ADEOfWaterBody",
+  "table": "property"
+}

--- a/schema-mapping/data-types/waterbody/ADEOfWaterGroundSurface.json
+++ b/schema-mapping/data-types/waterbody/ADEOfWaterGroundSurface.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "wtr:ADEOfWaterGroundSurface",
+  "table": "property"
+}

--- a/schema-mapping/data-types/waterbody/ADEOfWaterSurface.json
+++ b/schema-mapping/data-types/waterbody/ADEOfWaterSurface.json
@@ -1,0 +1,4 @@
+{
+  "identifier": "wtr:ADEOfWaterSurface",
+  "table": "property"
+}


### PR DESCRIPTION
This PR extends the schema-mapping and register every CityGML's abstract ADE hook into the `datatype` table. These meta-info are required for supporting ADE.