### PR TITLE
Feature properties must provide their target feature

### DIFF
--- a/json-schema/schema-mapping.schema.json
+++ b/json-schema/schema-mapping.schema.json
@@ -151,7 +151,8 @@
             "value": {
               "$ref": "#/$defs/value"
             },
-            "type": false
+            "type": false,
+            "target": false
           }
         },
         {
@@ -161,6 +162,26 @@
           ],
           "properties": {
             "type": {
+              "type": "string",
+              "not": {
+                "const": "core:FeatureProperty"
+              }
+            },
+            "value": false,
+            "target": false
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "target"
+          ],
+          "properties": {
+            "type": {
+              "const": "core:FeatureProperty"
+            },
+            "target": {
               "type": "string"
             },
             "value": false
@@ -170,7 +191,8 @@
           "type": "object",
           "properties": {
             "value": false,
-            "type": false
+            "type": false,
+            "target": false
           }
         }
       ]

--- a/schema-mapping/data-types/cityobjectgroup/Role.json
+++ b/schema-mapping/data-types/cityobjectgroup/Role.json
@@ -6,6 +6,7 @@
       "name": "groupMember",
       "namespace": "http://3dcitydb.org/3dcitydb/cityobjectgroup/5.0",
       "type": "core:FeatureProperty",
+      "target": "core:AbstractCityObject",
       "join": {
         "table": "property",
         "fromColumn": "parent_id",

--- a/schema-mapping/data-types/core/CityObjectRelation.json
+++ b/schema-mapping/data-types/core/CityObjectRelation.json
@@ -6,6 +6,7 @@
       "name": "relatedTo",
       "namespace": "http://3dcitydb.org/3dcitydb/core/5.0",
       "type": "core:FeatureProperty",
+      "target": "core:AbstractCityObject",
       "join": {
         "table": "property",
         "fromColumn": "parent_id",

--- a/schema-mapping/data-types/dynamizer/SensorConnection.json
+++ b/schema-mapping/data-types/dynamizer/SensorConnection.json
@@ -136,6 +136,7 @@
       "name": "sensorLocation",
       "namespace": "http://3dcitydb.org/3dcitydb/dynamizer/5.0",
       "type": "core:FeatureProperty",
+      "target": "core:AbstractCityObject",
       "join": {
         "table": "property",
         "fromColumn": "parent_id",

--- a/schema-mapping/data-types/dynamizer/TimeseriesComponent.json
+++ b/schema-mapping/data-types/dynamizer/TimeseriesComponent.json
@@ -26,6 +26,7 @@
       "name": "timeseries",
       "namespace": "http://3dcitydb.org/3dcitydb/dynamizer/5.0",
       "type": "core:FeatureProperty",
+      "target": "dyn:AbstractTimeseries",
       "join": {
         "table": "property",
         "fromColumn": "parent_id",

--- a/schema-mapping/data-types/versioning/Transaction.json
+++ b/schema-mapping/data-types/versioning/Transaction.json
@@ -16,6 +16,7 @@
       "name": "oldFeature",
       "namespace": "http://3dcitydb.org/3dcitydb/versioning/5.0",
       "type": "core:FeatureProperty",
+      "target": "core:AbstractFeatureWithLifespan",
       "join": {
         "table": "property",
         "fromColumn": "parent_id",
@@ -26,6 +27,7 @@
       "name": "newFeature",
       "namespace": "http://3dcitydb.org/3dcitydb/versioning/5.0",
       "type": "core:FeatureProperty",
+      "target": "core:AbstractFeatureWithLifespan",
       "join": {
         "table": "property",
         "fromColumn": "parent_id",

--- a/schema-mapping/feature-types/bridge/AbstractBridge.json
+++ b/schema-mapping/feature-types/bridge/AbstractBridge.json
@@ -25,22 +25,26 @@
     {
       "name": "bridgeConstructiveElement",
       "namespace": "http://3dcitydb.org/3dcitydb/bridge/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "brid:BridgeConstructiveElement"
     },
     {
       "name": "bridgeInstallation",
       "namespace": "http://3dcitydb.org/3dcitydb/bridge/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "brid:BridgeInstallation"
     },
     {
       "name": "bridgeRoom",
       "namespace": "http://3dcitydb.org/3dcitydb/bridge/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "brid:BridgeRoom"
     },
     {
       "name": "bridgeFurniture",
       "namespace": "http://3dcitydb.org/3dcitydb/bridge/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "brid:BridgeFurniture"
     },
     {
       "name": "address",

--- a/schema-mapping/feature-types/bridge/Bridge.json
+++ b/schema-mapping/feature-types/bridge/Bridge.json
@@ -5,7 +5,8 @@
     {
       "name": "bridgePart",
       "namespace": "http://3dcitydb.org/3dcitydb/bridge/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "brid:BridgePart"
     }
   ]
 }

--- a/schema-mapping/feature-types/bridge/BridgeRoom.json
+++ b/schema-mapping/feature-types/bridge/BridgeRoom.json
@@ -20,12 +20,14 @@
     {
       "name": "bridgeFurniture",
       "namespace": "http://3dcitydb.org/3dcitydb/bridge/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "brid:BridgeFurniture"
     },
     {
       "name": "bridgeInstallation",
       "namespace": "http://3dcitydb.org/3dcitydb/bridge/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "brid:BridgeInstallation"
     },
     {
       "name": "lod4Solid",

--- a/schema-mapping/feature-types/building/AbstractBuilding.json
+++ b/schema-mapping/feature-types/building/AbstractBuilding.json
@@ -45,27 +45,32 @@
     {
       "name": "buildingConstructiveElement",
       "namespace": "http://3dcitydb.org/3dcitydb/building/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "bldg:BuildingConstructiveElement"
     },
     {
       "name": "buildingInstallation",
       "namespace": "http://3dcitydb.org/3dcitydb/building/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "bldg:BuildingInstallation"
     },
     {
       "name": "buildingRoom",
       "namespace": "http://3dcitydb.org/3dcitydb/building/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "bldg:BuildingRoom"
     },
     {
       "name": "buildingFurniture",
       "namespace": "http://3dcitydb.org/3dcitydb/building/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "bldg:BuildingFurniture"
     },
     {
       "name": "buildingSubdivision",
       "namespace": "http://3dcitydb.org/3dcitydb/building/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "bldg:AbstractBuildingSubdivision"
     },
     {
       "name": "address",

--- a/schema-mapping/feature-types/building/AbstractBuildingSubdivision.json
+++ b/schema-mapping/feature-types/building/AbstractBuildingSubdivision.json
@@ -30,22 +30,26 @@
     {
       "name": "buildingConstructiveElement",
       "namespace": "http://3dcitydb.org/3dcitydb/building/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "bldg:BuildingConstructiveElement"
     },
     {
       "name": "buildingFurniture",
       "namespace": "http://3dcitydb.org/3dcitydb/building/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "bldg:BuildingFurniture"
     },
     {
       "name": "buildingInstallation",
       "namespace": "http://3dcitydb.org/3dcitydb/building/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "bldg:BuildingInstallation"
     },
     {
       "name": "buildingRoom",
       "namespace": "http://3dcitydb.org/3dcitydb/building/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "bldg:BuildingRoom"
     }
   ]
 }

--- a/schema-mapping/feature-types/building/Building.json
+++ b/schema-mapping/feature-types/building/Building.json
@@ -5,7 +5,8 @@
     {
       "name": "buildingPart",
       "namespace": "http://3dcitydb.org/3dcitydb/building/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "bldg:BuildingPart"
     }
   ]
 }

--- a/schema-mapping/feature-types/building/BuildingRoom.json
+++ b/schema-mapping/feature-types/building/BuildingRoom.json
@@ -25,12 +25,14 @@
     {
       "name": "buildingFurniture",
       "namespace": "http://3dcitydb.org/3dcitydb/building/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "bldg:BuildingFurniture"
     },
     {
       "name": "buildingInstallation",
       "namespace": "http://3dcitydb.org/3dcitydb/building/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "bldg:BuildingInstallation"
     },
     {
       "name": "lod4Solid",

--- a/schema-mapping/feature-types/building/BuildingUnit.json
+++ b/schema-mapping/feature-types/building/BuildingUnit.json
@@ -5,7 +5,8 @@
     {
       "name": "storey",
       "namespace": "http://3dcitydb.org/3dcitydb/building/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "bldg:Storey"
     },
     {
       "name": "address",

--- a/schema-mapping/feature-types/building/Storey.json
+++ b/schema-mapping/feature-types/building/Storey.json
@@ -5,7 +5,8 @@
     {
       "name": "buildingUnit",
       "namespace": "http://3dcitydb.org/3dcitydb/building/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "bldg:BuildingUnit"
     }
   ]
 }

--- a/schema-mapping/feature-types/cityobjectgroup/CityObjectGroup.json
+++ b/schema-mapping/feature-types/cityobjectgroup/CityObjectGroup.json
@@ -25,7 +25,8 @@
     {
       "name": "parent",
       "namespace": "http://3dcitydb.org/3dcitydb/cityobjectgroup/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "core:AbstractCityObject"
     },
     {
       "name": "geometry",

--- a/schema-mapping/feature-types/construction/AbstractConstructionSurface.json
+++ b/schema-mapping/feature-types/construction/AbstractConstructionSurface.json
@@ -5,7 +5,8 @@
     {
       "name": "fillingSurface",
       "namespace": "http://3dcitydb.org/3dcitydb/construction/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "con:AbstractFillingSurface"
     }
   ]
 }

--- a/schema-mapping/feature-types/construction/AbstractConstructiveElement.json
+++ b/schema-mapping/feature-types/construction/AbstractConstructiveElement.json
@@ -10,7 +10,8 @@
     {
       "name": "filling",
       "namespace": "http://3dcitydb.org/3dcitydb/construction/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "con:AbstractFillingElement"
     }
   ]
 }

--- a/schema-mapping/feature-types/core/AbstractCityObject.json
+++ b/schema-mapping/feature-types/core/AbstractCityObject.json
@@ -10,7 +10,8 @@
     {
       "name": "generalizesTo",
       "namespace": "http://3dcitydb.org/3dcitydb/core/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "core:AbstractCityObject"
     },
     {
       "name": "relativeToTerrain",
@@ -25,7 +26,8 @@
     {
       "name": "relatedTo",
       "namespace": "http://3dcitydb.org/3dcitydb/core/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "core:AbstractCityObject"
     },
     {
       "name": "appearance",
@@ -35,7 +37,8 @@
     {
       "name": "dynamizer",
       "namespace": "http://3dcitydb.org/3dcitydb/core/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "core:AbstractDynamizer"
     }
   ]
 }

--- a/schema-mapping/feature-types/core/AbstractPhysicalSpace.json
+++ b/schema-mapping/feature-types/core/AbstractPhysicalSpace.json
@@ -20,7 +20,8 @@
     {
       "name": "pointCloud",
       "namespace": "http://3dcitydb.org/3dcitydb/core/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "core:AbstractPointCloud"
     }
   ]
 }

--- a/schema-mapping/feature-types/core/AbstractSpace.json
+++ b/schema-mapping/feature-types/core/AbstractSpace.json
@@ -20,7 +20,8 @@
     {
       "name": "boundary",
       "namespace": "http://3dcitydb.org/3dcitydb/core/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "core:AbstractSpaceBoundary"
     },
     {
       "name": "lod0Point",

--- a/schema-mapping/feature-types/core/AbstractThematicSurface.json
+++ b/schema-mapping/feature-types/core/AbstractThematicSurface.json
@@ -30,7 +30,8 @@
     {
       "name": "pointCloud",
       "namespace": "http://3dcitydb.org/3dcitydb/core/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "core:AbstractPointCloud"
     },
     {
       "name": "lod4MultiSurface",

--- a/schema-mapping/feature-types/core/CityModel.json
+++ b/schema-mapping/feature-types/core/CityModel.json
@@ -5,17 +5,20 @@
     {
       "name": "cityObjectMember",
       "namespace": "http://3dcitydb.org/3dcitydb/core/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "core:AbstractCityObject"
     },
     {
       "name": "versionMember",
       "namespace": "http://3dcitydb.org/3dcitydb/core/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "core:AbstractVersion"
     },
     {
       "name": "versionTransitionMember",
       "namespace": "http://3dcitydb.org/3dcitydb/core/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "core:AbstractVersionTransition"
     },
     {
       "name": "appearanceMember",

--- a/schema-mapping/feature-types/dynamizer/Dynamizer.json
+++ b/schema-mapping/feature-types/dynamizer/Dynamizer.json
@@ -20,7 +20,8 @@
     {
       "name": "dynamicData",
       "namespace": "http://3dcitydb.org/3dcitydb/dynamizer/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "dyn:AbstractTimeseries"
     },
     {
       "name": "sensorConnection",

--- a/schema-mapping/feature-types/relief/MassPointRelief.json
+++ b/schema-mapping/feature-types/relief/MassPointRelief.json
@@ -10,7 +10,8 @@
     {
       "name": "pointCloud",
       "namespace": "http://3dcitydb.org/3dcitydb/relief/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "core:AbstractPointCloud"
     }
   ]
 }

--- a/schema-mapping/feature-types/relief/ReliefFeature.json
+++ b/schema-mapping/feature-types/relief/ReliefFeature.json
@@ -10,7 +10,8 @@
     {
       "name": "reliefComponent",
       "namespace": "http://3dcitydb.org/3dcitydb/relief/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "dem:AbstractReliefComponent"
     }
   ]
 }

--- a/schema-mapping/feature-types/transportation/AbstractTransportationSpace.json
+++ b/schema-mapping/feature-types/transportation/AbstractTransportationSpace.json
@@ -15,22 +15,26 @@
     {
       "name": "trafficSpace",
       "namespace": "http://3dcitydb.org/3dcitydb/transportation/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "tran:TrafficSpace"
     },
     {
       "name": "auxiliaryTrafficSpace",
       "namespace": "http://3dcitydb.org/3dcitydb/transportation/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "tran:AuxiliaryTrafficSpace"
     },
     {
       "name": "hole",
       "namespace": "http://3dcitydb.org/3dcitydb/transportation/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "tran:Hole"
     },
     {
       "name": "marking",
       "namespace": "http://3dcitydb.org/3dcitydb/transportation/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "tran:Marking"
     },
     {
       "name": "lod1MultiSurface",

--- a/schema-mapping/feature-types/transportation/Railway.json
+++ b/schema-mapping/feature-types/transportation/Railway.json
@@ -20,12 +20,14 @@
     {
       "name": "section",
       "namespace": "http://3dcitydb.org/3dcitydb/transportation/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "tran:Section"
     },
     {
       "name": "intersection",
       "namespace": "http://3dcitydb.org/3dcitydb/transportation/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "tran:Intersection"
     }
   ]
 }

--- a/schema-mapping/feature-types/transportation/Road.json
+++ b/schema-mapping/feature-types/transportation/Road.json
@@ -20,12 +20,14 @@
     {
       "name": "section",
       "namespace": "http://3dcitydb.org/3dcitydb/transportation/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "tran:Section"
     },
     {
       "name": "intersection",
       "namespace": "http://3dcitydb.org/3dcitydb/transportation/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "tran:Intersection"
     }
   ]
 }

--- a/schema-mapping/feature-types/transportation/TrafficSpace.json
+++ b/schema-mapping/feature-types/transportation/TrafficSpace.json
@@ -35,17 +35,20 @@
     {
       "name": "predecessor",
       "namespace": "http://3dcitydb.org/3dcitydb/transportation/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "tran:TrafficSpace"
     },
     {
       "name": "successor",
       "namespace": "http://3dcitydb.org/3dcitydb/transportation/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "tran:TrafficSpace"
     },
     {
       "name": "clearanceSpace",
       "namespace": "http://3dcitydb.org/3dcitydb/transportation/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "tran:ClearanceSpace"
     }
   ]
 }

--- a/schema-mapping/feature-types/transportation/Waterway.json
+++ b/schema-mapping/feature-types/transportation/Waterway.json
@@ -20,12 +20,14 @@
     {
       "name": "section",
       "namespace": "http://3dcitydb.org/3dcitydb/transportation/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "tran:Section"
     },
     {
       "name": "intersection",
       "namespace": "http://3dcitydb.org/3dcitydb/transportation/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "tran:Intersection"
     }
   ]
 }

--- a/schema-mapping/feature-types/tunnel/AbstractTunnel.json
+++ b/schema-mapping/feature-types/tunnel/AbstractTunnel.json
@@ -20,22 +20,26 @@
     {
       "name": "tunnelConstructiveElement",
       "namespace": "http://3dcitydb.org/3dcitydb/tunnel/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "tun:TunnelConstructiveElement"
     },
     {
       "name": "tunnelInstallation",
       "namespace": "http://3dcitydb.org/3dcitydb/tunnel/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "tun:TunnelInstallation"
     },
     {
       "name": "hollowSpace",
       "namespace": "http://3dcitydb.org/3dcitydb/tunnel/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "tun:HollowSpace"
     },
     {
       "name": "tunnelFurniture",
       "namespace": "http://3dcitydb.org/3dcitydb/tunnel/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "tun:TunnelFurniture"
     },
     {
       "name": "lod1MultiSurface",

--- a/schema-mapping/feature-types/tunnel/HollowSpace.json
+++ b/schema-mapping/feature-types/tunnel/HollowSpace.json
@@ -20,12 +20,14 @@
     {
       "name": "tunnelFurniture",
       "namespace": "http://3dcitydb.org/3dcitydb/tunnel/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "tun:TunnelFurniture"
     },
     {
       "name": "tunnelInstallation",
       "namespace": "http://3dcitydb.org/3dcitydb/tunnel/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "tun:TunnelInstallation"
     },
     {
       "name": "lod4Solid",

--- a/schema-mapping/feature-types/tunnel/Tunnel.json
+++ b/schema-mapping/feature-types/tunnel/Tunnel.json
@@ -5,7 +5,8 @@
     {
       "name": "tunnelPart",
       "namespace": "http://3dcitydb.org/3dcitydb/tunnel/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "tun:TunnelPart"
     }
   ]
 }

--- a/schema-mapping/feature-types/version/Version.json
+++ b/schema-mapping/feature-types/version/Version.json
@@ -10,7 +10,8 @@
     {
       "name": "versionMember",
       "namespace": "http://3dcitydb.org/3dcitydb/versioning/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "core:AbstractFeatureWithLifespan"
     }
   ]
 }

--- a/schema-mapping/feature-types/version/VersionTransition.json
+++ b/schema-mapping/feature-types/version/VersionTransition.json
@@ -20,12 +20,14 @@
     {
       "name": "from",
       "namespace": "http://3dcitydb.org/3dcitydb/versioning/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "vers:Version"
     },
     {
       "name": "to",
       "namespace": "http://3dcitydb.org/3dcitydb/versioning/5.0",
-      "type": "core:FeatureProperty"
+      "type": "core:FeatureProperty",
+      "target": "vers:Version"
     },
     {
       "name": "transaction",


### PR DESCRIPTION
This PR changes the JSON definition for `core:FeatureProperty`. The `target` feature type must now be provided.

Before:
```json
{
 "name": "buildingPart",
 "namespace": "http://3dcitydb.org/3dcitydb/building/5.0",
 "type": "core:FeatureProperty"
}
``` 

After:
```json
{
 "name": "buildingPart",
 "namespace": "http://3dcitydb.org/3dcitydb/building/5.0",
 "type": "core:FeatureProperty",
 "target": "bldg:BuildingPart"
}
``` 