### PR TITLE
Use partial indexes for property value columns

### DIFF
--- a/postgresql/db-schema/3dcitydb-schema.dbs
+++ b/postgresql/db-schema/3dcitydb-schema.dbs
@@ -312,50 +312,50 @@
 			<index name="property_parent_fkx" unique="NORMAL" >
 				<column name="parent_id" />
 			</index>
-			<index name="property_val_feature_fkx" unique="NORMAL" >
-				<column name="val_feature_id" />
-			</index>
-			<index name="property_val_string_inx" unique="NORMAL" >
-				<column name="val_string" />
-			</index>
-			<index name="property_val_uom_inx" unique="NORMAL" >
-				<column name="val_uom" />
-			</index>
-			<index name="property_val_uri_inx" unique="NORMAL" >
-				<column name="val_uri" />
-			</index>
-			<index name="property_val_lod_inx" unique="NORMAL" >
-				<column name="val_lod" />
-			</index>
-			<index name="property_val_int_inx" unique="NORMAL" >
-				<column name="val_int" />
-			</index>
-			<index name="property_val_double_inx" unique="NORMAL" >
-				<column name="val_double" />
-			</index>
-			<index name="property_val_date_inx" unique="NORMAL" >
-				<column name="val_timestamp" />
-			</index>
-			<index name="property_val_geometry_fkx" unique="NORMAL" >
-				<column name="val_geometry_id" />
-			</index>
-			<index name="property_val_implicitgeom_fkx" unique="NORMAL" >
-				<column name="val_implicitgeom_id" />
-			</index>
-			<index name="property_val_appearance_fkx" unique="NORMAL" >
-				<column name="val_appearance_id" />
-			</index>
 			<index name="property_namespace_inx" unique="NORMAL" >
 				<column name="namespace_id" />
 			</index>
-			<index name="property_val_relation_type_inx" unique="NORMAL" >
-				<column name="val_relation_type" />
-			</index>
-			<index name="property_val_address_fkx" unique="NORMAL" >
-				<column name="val_address_id" />
-			</index>
 			<index name="property_name_inx" unique="NORMAL" >
 				<column name="name" />
+			</index>
+			<index name="property_val_feature_fkx" unique="NORMAL" options="WHERE val_feature_id IS NOT NULL" >
+				<column name="val_feature_id" />
+			</index>
+			<index name="property_val_string_inx" unique="NORMAL" options="WHERE val_string IS NOT NULL" >
+				<column name="val_string" />
+			</index>
+			<index name="property_val_uom_inx" unique="NORMAL" options="WHERE val_uom IS NOT NULL" >
+				<column name="val_uom" />
+			</index>
+			<index name="property_val_uri_inx" unique="NORMAL" options="WHERE val_uri IS NOT NULL" >
+				<column name="val_uri" />
+			</index>
+			<index name="property_val_lod_inx" unique="NORMAL" options="WHERE val_lod IS NOT NULL" >
+				<column name="val_lod" />
+			</index>
+			<index name="property_val_int_inx" unique="NORMAL" options="WHERE val_int IS NOT NULL" >
+				<column name="val_int" />
+			</index>
+			<index name="property_val_double_inx" unique="NORMAL" options="WHERE val_double IS NOT NULL" >
+				<column name="val_double" />
+			</index>
+			<index name="property_val_date_inx" unique="NORMAL" options="WHERE val_timestamp IS NOT NULL" >
+				<column name="val_timestamp" />
+			</index>
+			<index name="property_val_geometry_fkx" unique="NORMAL" options="WHERE val_geometry_id IS NOT NULL" >
+				<column name="val_geometry_id" />
+			</index>
+			<index name="property_val_implicitgeom_fkx" unique="NORMAL" options="WHERE val_implicitgeom_id IS NOT NULL" >
+				<column name="val_implicitgeom_id" />
+			</index>
+			<index name="property_val_appearance_fkx" unique="NORMAL" options="WHERE val_appearance_id IS NOT NULL" >
+				<column name="val_appearance_id" />
+			</index>
+			<index name="property_val_relation_type_inx" unique="NORMAL" options="WHERE val_relation_type IS NOT NULL" >
+				<column name="val_relation_type" />
+			</index>
+			<index name="property_val_address_fkx" unique="NORMAL" options="WHERE val_address_id IS NOT NULL" >
+				<column name="val_address_id" />
 			</index>
 			<fk name="property_appearance_fk" to_schema="citydb" to_table="appearance" delete_action="cascade" >
 				<fk_column name="val_appearance_id" pk="id" />

--- a/postgresql/sql-scripts/schema/schema.sql
+++ b/postgresql/sql-scripts/schema/schema.sql
@@ -233,35 +233,35 @@ CREATE INDEX property_feature_fkx ON property  ( feature_id );
 
 CREATE INDEX property_parent_fkx ON property  ( parent_id );
 
-CREATE INDEX property_val_feature_fkx ON property  ( val_feature_id );
-
-CREATE INDEX property_val_string_inx ON property  ( val_string );
-
-CREATE INDEX property_val_uom_inx ON property  ( val_uom );
-
-CREATE INDEX property_val_uri_inx ON property  ( val_uri );
-
-CREATE INDEX property_val_lod_inx ON property  ( val_lod );
-
-CREATE INDEX property_val_int_inx ON property  ( val_int );
-
-CREATE INDEX property_val_double_inx ON property  ( val_double );
-
-CREATE INDEX property_val_date_inx ON property  ( val_timestamp );
-
-CREATE INDEX property_val_geometry_fkx ON property  ( val_geometry_id );
-
-CREATE INDEX property_val_implicitgeom_fkx ON property  ( val_implicitgeom_id );
-
-CREATE INDEX property_val_appearance_fkx ON property  ( val_appearance_id );
-
 CREATE INDEX property_namespace_inx ON property  ( namespace_id );
 
-CREATE INDEX property_val_relation_type_inx ON property  ( val_relation_type );
-
-CREATE INDEX property_val_address_fkx ON property  ( val_address_id );
-
 CREATE INDEX property_name_inx ON property  ( name );
+
+CREATE INDEX property_val_feature_fkx ON property  ( val_feature_id ) WHERE val_feature_id IS NOT NULL;
+
+CREATE INDEX property_val_string_inx ON property  ( val_string ) WHERE val_string IS NOT NULL;
+
+CREATE INDEX property_val_uom_inx ON property  ( val_uom ) WHERE val_uom IS NOT NULL;
+
+CREATE INDEX property_val_uri_inx ON property  ( val_uri ) WHERE val_uri IS NOT NULL;
+
+CREATE INDEX property_val_lod_inx ON property  ( val_lod ) WHERE val_lod IS NOT NULL;
+
+CREATE INDEX property_val_int_inx ON property  ( val_int ) WHERE val_int IS NOT NULL;
+
+CREATE INDEX property_val_double_inx ON property  ( val_double ) WHERE val_double IS NOT NULL;
+
+CREATE INDEX property_val_date_inx ON property  ( val_timestamp ) WHERE val_timestamp IS NOT NULL;
+
+CREATE INDEX property_val_geometry_fkx ON property  ( val_geometry_id ) WHERE val_geometry_id IS NOT NULL;
+
+CREATE INDEX property_val_implicitgeom_fkx ON property  ( val_implicitgeom_id ) WHERE val_implicitgeom_id IS NOT NULL;
+
+CREATE INDEX property_val_appearance_fkx ON property  ( val_appearance_id ) WHERE val_appearance_id IS NOT NULL;
+
+CREATE INDEX property_val_relation_type_inx ON property  ( val_relation_type ) WHERE val_relation_type IS NOT NULL;
+
+CREATE INDEX property_val_address_fkx ON property  ( val_address_id ) WHERE val_address_id IS NOT NULL;
 
 CREATE  TABLE surface_data ( 
 	id                   bigint DEFAULT nextval('surface_data_seq'::regclass) NOT NULL  ,


### PR DESCRIPTION
This PR proposes to use partial indexes on all `val_*` columns of the `property` table.

At the moment, the initial import of a dataset takes on average 2X longer if all indexes are enabled, compared to when the indexes have been dropped before importing using the `citydb-tool`. Note that the `citydb-tool` does not drop all indexes in the database but focuses on the spatial indexes, the indexes on the `val_*` columns of the `property` table and on some columns of the `feature` table.

Especially the  `val_*` columns of the `property` table are sparsely populated and typically contain a lof ot `NULL` values. The idea of this PR is therefore to exclude `NULL` values from the index. This keeps the index much smaller and updating the index becomes much faster. PostgreSQL supports partial indexes by simply adding a condition, for example:

```sql
CREATE INDEX property_val_int_inx ON property  ( val_int ) WHERE val_int IS NOT NULL;
```

With partial indexes, the initial import only takes ~1.2X times longer with all indexes enabled in my tests. I think this looks like a good compromise because users don't have to be careful whether or not to drop indexes before an import (and users often forget to drop indexes or, even worse, to re-create them afterwards...).

The impact of using partial indexes is, of course, that a query checking for `NULL` values like `select * from property where val_int is null` would not be able to use the index and thus require a full table scan. But my feeling is that most all-day queries are tests against specific values (e.g., = 5, < 20, >= 100). And if there are really tests for `NULL` values, typical queries would at least involve the attribute name, eg. `select * from property where name='myAttribute' and val_int is null`. And such queries would benefit from the index on the `name` value.

I would like to initiate a discussion whether we should switch to partial indexes for the `val_*` columns. @thomashkolbe, @yaozhihang, your input and tests are highly welcome. In my tests, I used the untextured Berlin dataset (~550k buildings) on a local computer. I always compared the intial import times. I expect subsequent imports to get slower over time because the index grows. But this is also true for full indexes, of course.

Here are the setup scripts with partial indexes for your convenience: 
[3dcitydb-5.0.0-partial-indexes.zip](https://github.com/user-attachments/files/17784702/3dcitydb-5.0.0-partial-indexes.zip). After setting up a 3DCityDB with these scripts, use version 0.9.0-beta of the citydb-tool for testing.
