### PR TITLE
Improve deletion of feature properties

### DIFF
--- a/postgresql/db-schema/3dcitydb-schema.dbs
+++ b/postgresql/db-schema/3dcitydb-schema.dbs
@@ -359,7 +359,7 @@
 			<fk name="property_feature_fk" to_schema="citydb" to_table="feature" >
 				<fk_column name="feature_id" pk="id" />
 			</fk>
-			<fk name="property_val_feature_fk" to_schema="citydb" to_table="feature" delete_action="cascade" >
+			<fk name="property_val_feature_fk" to_schema="citydb" to_table="feature" delete_action="setNull" >
 				<fk_column name="val_feature_id" pk="id" />
 			</fk>
 			<fk name="property_val_implicitgeom_fk" to_schema="citydb" to_table="implicit_geometry" delete_action="cascade" >

--- a/postgresql/sql-scripts/citydb-pkg/delete.sql
+++ b/postgresql/sql-scripts/citydb-pkg/delete.sql
@@ -38,24 +38,20 @@ DECLARE
   deleted_ids bigint[] := '{}';
 BEGIN
   PERFORM
+    citydb_pkg.delete_property_row(array_agg(p.id))
+  FROM
+    property p,
+    unnest($1) AS a(a_id)
+  WHERE
+    p.feature_id = a.a_id;
+
+  PERFORM
     citydb_pkg.delete_property(array_agg(p.id))
-  FROM (
-    SELECT
-      p.id
-    FROM
-      property p,
-      unnest($1) AS a(a_id)
-    WHERE
-      p.feature_id = a.a_id
-    UNION ALL
-    SELECT
-      p.id
-    FROM
-      property p,
-      unnest($1) AS a(a_id)
-    WHERE
-      p.val_feature_id = a.a_id AND p.datatype_id = 10
-  ) AS p;
+  FROM
+    property p,
+    unnest($1) AS a(a_id)
+  WHERE
+    p.val_feature_id = a.a_id;
 
   WITH delete_objects AS (
     DELETE FROM

--- a/postgresql/sql-scripts/citydb-pkg/delete.sql
+++ b/postgresql/sql-scripts/citydb-pkg/delete.sql
@@ -54,7 +54,7 @@ BEGIN
       property p,
       unnest($1) AS a(a_id)
     WHERE
-      p.val_feature_id = a.a_id
+      p.val_feature_id = a.a_id AND p.datatype_id = 10
   ) AS p;
 
   WITH delete_objects AS (

--- a/postgresql/sql-scripts/citydb-pkg/delete.sql
+++ b/postgresql/sql-scripts/citydb-pkg/delete.sql
@@ -38,12 +38,24 @@ DECLARE
   deleted_ids bigint[] := '{}';
 BEGIN
   PERFORM
-    citydb_pkg.delete_property_row(array_agg(p.id))
-  FROM
-    property p,
-    unnest($1) AS a(a_id)
-  WHERE
-    p.feature_id = a.a_id;
+    citydb_pkg.delete_property(array_agg(p.id))
+  FROM (
+    SELECT
+      p.id
+    FROM
+      property p,
+      unnest($1) AS a(a_id)
+    WHERE
+      p.feature_id = a.a_id
+    UNION ALL
+    SELECT
+      p.id
+    FROM
+      property p,
+      unnest($1) AS a(a_id)
+    WHERE
+      p.val_feature_id = a.a_id
+  ) AS p;
 
   WITH delete_objects AS (
     DELETE FROM
@@ -209,8 +221,26 @@ LANGUAGE plpgsql STRICT;
 CREATE OR REPLACE FUNCTION citydb_pkg.delete_property(pid_array bigint[]) RETURNS SETOF BIGINT AS
 $body$
 DECLARE
+  cascade_delete_ids bigint[] := '{}';
   property_ids bigint[] := '{}';
 BEGIN
+  WITH parent_refs AS (
+    SELECT
+      c.id, citydb_pkg.delete_property(p.id)
+    FROM
+      property c
+    INNER JOIN unnest($1) AS a(a_id) ON c.id = a.a_id
+    INNER JOIN property p ON p.id = c.parent_id
+    WHERE
+      p.name = c.name AND p.namespace_id = c.namespace_id
+  )
+  SELECT
+    array_agg(id)
+  INTO
+    cascade_delete_ids
+  FROM
+    parent_refs;
+
   WITH RECURSIVE child_refs AS (
     SELECT
       p.id
@@ -238,7 +268,9 @@ BEGIN
   RETURN QUERY
     SELECT citydb_pkg.delete_property_row(property_ids)
     INTERSECT
-    SELECT unnest($1);
+    SELECT unnest($1)
+    UNION
+    SELECT unnest(cascade_delete_ids);
 END;
 $body$
 LANGUAGE plpgsql STRICT;

--- a/postgresql/sql-scripts/schema/schema.sql
+++ b/postgresql/sql-scripts/schema/schema.sql
@@ -343,7 +343,7 @@ ALTER TABLE property ADD CONSTRAINT property_appearance_fk FOREIGN KEY ( val_app
 
 ALTER TABLE property ADD CONSTRAINT property_feature_fk FOREIGN KEY ( feature_id ) REFERENCES feature( id );
 
-ALTER TABLE property ADD CONSTRAINT property_val_feature_fk FOREIGN KEY ( val_feature_id ) REFERENCES feature( id ) ON DELETE CASCADE;
+ALTER TABLE property ADD CONSTRAINT property_val_feature_fk FOREIGN KEY ( val_feature_id ) REFERENCES feature( id ) ON DELETE SET NULL;
 
 ALTER TABLE property ADD CONSTRAINT property_val_implicitgeom_fk FOREIGN KEY ( val_implicitgeom_id ) REFERENCES implicit_geometry( id ) ON DELETE CASCADE;
 


### PR DESCRIPTION
This PR improves the deletion of feature properties that are split across two rows of the `PROPERTY` table in a parent-child relationship. This splitting results from the mapping of UML association classes, as specified in the [CityGML 3.0 GML standard](https://docs.ogc.org/is/21-006r2/21-006r2.html#association-classes-section), and occurs when the feature property includes additional attributes—such as in `grp:groupMember` or `core:relatedTo`.

Previously, deleting the child row did not remove the associated parent row. This has now been fixed.
