### PR TITLE
ci: update GitHub Actions to Node 24 runtime & drop battila7/get-version-action

### DIFF
--- a/.github/workflows/build-3dcitydb-scripts.yml
+++ b/.github/workflows/build-3dcitydb-scripts.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
       - name: Install Ajv JSON schema validator
         run: npm install -g ajv-cli
       - name: Validate schema mapping
@@ -20,14 +20,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
         with:
           cache-disabled: true
       - name: Grant execute permission to Gradle

--- a/.github/workflows/psql-docker-build-push-edge.yml
+++ b/.github/workflows/psql-docker-build-push-edge.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     -
       name: Parse short sha
-      uses: benjlevesque/short-sha@v3.0
+      uses: benjlevesque/short-sha@v4.0
       id: short-sha
     -
       name: set lower case owner name
@@ -32,17 +32,17 @@ jobs:
         OWNER: '${{ github.repository_owner }}'
     -
       name: Checkout repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     -
       name: Docker login Dockerhub
       id: docker_login
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_PASSWORD }}
     -
       name: Login to GitHub Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -50,7 +50,7 @@ jobs:
     -
       name: Extract metadata (tags, labels) for docker image
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@v6
       with:
         images: |
           ${{ env.OWNER_LC }}/${{ env.IMAGE_NAME }}
@@ -74,7 +74,7 @@ jobs:
     -
       name: Build and push image
       id: docker_build
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         context: .
         push: true

--- a/.github/workflows/psql-docker-build-push-pr.yml
+++ b/.github/workflows/psql-docker-build-push-pr.yml
@@ -25,7 +25,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Short SHA of latest commit to PR
         id: sha-short
         run: |
@@ -37,14 +37,14 @@ jobs:
         env:
           OWNER: "${{ github.repository_owner }}"
       - name: Log in to the Github Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract metadata (tags, labels) for docker image
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             ${{ env.REGISTRY }}/${{ env.OWNER_LC }}/${{ env.IMAGE_NAME }}
@@ -66,7 +66,7 @@ jobs:
             org.opencontainers.image.source=https://github.com/3dcitydb/3dcitydb
       - name: Build and push image
         id: docker_build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true

--- a/.github/workflows/psql-docker-build-push-release.yml
+++ b/.github/workflows/psql-docker-build-push-release.yml
@@ -29,9 +29,14 @@ jobs:
       name: Checkout repo
       uses: actions/checkout@v5
     -
-      name: Get release version without v
+      name: Get release version
       id: release_version
-      uses: battila7/get-version-action@v2
+      env:
+        REF_NAME: ${{ github.event.release.tag_name || github.ref_name }}
+      run: |
+        version="${REF_NAME}"
+        echo "version=${version}" >> "$GITHUB_OUTPUT"
+        echo "version-without-v=${version#v}" >> "$GITHUB_OUTPUT"
     -
       name: set lower case owner name
       run: |

--- a/.github/workflows/psql-docker-build-push-release.yml
+++ b/.github/workflows/psql-docker-build-push-release.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
     -
       name: Checkout repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     -
       name: Get release version without v
       id: release_version
@@ -41,13 +41,13 @@ jobs:
     -
       name: Docker login Dockerhub
       id: docker_login
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_PASSWORD }}
     -
       name: Login to GitHub Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -55,7 +55,7 @@ jobs:
     -
       name: Extract metadata (tags, labels) for docker image
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@v6
       with:
         images: |
           ${{ env.OWNER_LC }}/${{ env.IMAGE_NAME }}
@@ -88,7 +88,7 @@ jobs:
     -
       name: Build and publish
       id: docker_build
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         context: .
         push: true


### PR DESCRIPTION
## Why

GitHub Actions runners now default to **Node.js 24** (since 2026-06-16) and the Node.js 20 runtime is being removed (2026-09-16). Several actions in our workflows still declare `node20` (or older) in their `action.yml`, so the pipelines emit:

> Node.js 20 actions are deprecated. … Please check if updated versions of these actions are available that support Node.js 24.

Additionally, `battila7/get-version-action@v2` declares the ancient **node12** runtime and internally uses the deprecated `set-output` command, so it triggers **both** the Node.js and `set-output` deprecation warnings.

## What

**Commit 1 — bump actions to Node 24 native versions** (each verified against the target tag's `action.yml` `runs.using: node24`):

| Action | Old | New |
|---|---|---|
| actions/checkout | v4 | v5 |
| actions/setup-node | v4 | v5 |
| actions/setup-java | v4 | v5 |
| docker/login-action | v3 | v4 |
| docker/metadata-action | v5 | v6 |
| docker/build-push-action | v6 | v7 |
| gradle/actions/setup-gradle | v3 | v5 |
| benjlevesque/short-sha | v3.0 | v4.0 |

`dataaxiom/ghcr-cleanup-action@v1` already runs on node24 → unchanged.

**Commit 2 — replace `battila7/get-version-action`** with a small POSIX shell step that derives the version from the release tag and writes to `$GITHUB_OUTPUT`. The `version` / `version-without-v` outputs are preserved, so downstream references are unchanged. This clears the `set-output` deprecation.

## Validation

- YAML parsed for every changed workflow.
- `actionlint` clean (only pre-existing informational SC2086 notes in unrelated `run:` steps).
- Replacement shell logic unit-tested for `v1.2.3` / `1.2.3` tag forms.